### PR TITLE
Add RoSys simulation mode to the devkit driver node

### DIFF
--- a/devkit_driver/devkit_driver/devkit_driver_node.py
+++ b/devkit_driver/devkit_driver/devkit_driver_node.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
 
+import os
 import threading
 from pathlib import Path
 
 import rclpy
-from feldfreund_devkit import FeldfreundHardware, System, api
+import rclpy.parameter
+import rosys
+from feldfreund_devkit import FeldfreundHardware, FeldfreundSimulation, System, api
 from feldfreund_devkit.config import config_from_file
 from nicegui import app, ui, ui_run
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
+from rosgraph_msgs.msg import Clock
 
 from devkit_driver.modules import BMSHandler, BumperHandler, EStopHandler, OdomHandler, RobotBrainHandler, TwistHandler
 
@@ -19,14 +23,38 @@ class DevkitDriver(Node):
     def __init__(self, system: System):
         super().__init__('devkit_driver_node')
         self.system = system
-        assert isinstance(self.system.feldfreund, FeldfreundHardware)
-        self._robot_brain_handler = RobotBrainHandler(self, self.system.feldfreund.robot_brain)
+
+        if isinstance(self.system.feldfreund, FeldfreundHardware):
+            self.get_logger().info('Running in hardware mode')
+            self._robot_brain_handler = RobotBrainHandler(self, self.system.feldfreund.robot_brain)
+        elif isinstance(self.system.feldfreund, FeldfreundSimulation):
+            self.get_logger().info('Running in simulation mode')
+            self._clock_publisher = self.create_publisher(Clock, '/clock', 10)
+            self.set_parameters([rclpy.parameter.Parameter('use_sim_time',
+                                                           rclpy.parameter.Parameter.Type.BOOL,
+                                                           True)])
+            # Start clock publishing using rosys repeater for better integration
+            rosys.on_repeat(self._publish_clock, 0.01)
+        else:
+            raise TypeError(f'Unknown feldfreund type: {type(self.system.feldfreund)}')
+
+        # All other handlers work with both hardware and simulation
         self._odom_handler = OdomHandler(self, self.system.odometer)
         self._bms_handler = BMSHandler(self, self.system.feldfreund.bms)
         if self.system.feldfreund.bumper is not None:
             self._bumper_handler = BumperHandler(self, self.system.feldfreund.bumper, self.system.feldfreund.estop)
         self._twist_handler = TwistHandler(self, self.system.feldfreund.wheels)
         self._estop_handler = EStopHandler(self, self.system.feldfreund.estop)
+
+    def _publish_clock(self) -> None:
+        """Publish RoSys simulation time to ROS2 /clock topic."""
+        current_time = rosys.time()
+
+        msg = Clock()
+        msg.clock.sec = int(current_time)
+        msg.clock.nanosec = int((current_time - int(current_time)) * 1e9)
+
+        self._clock_publisher.publish(msg)
 
 
 def main() -> None:
@@ -35,6 +63,11 @@ def main() -> None:
 
 
 def on_startup() -> None:
+    # Check if simulation mode is requested via environment variable
+    simulation_mode = os.environ.get('FELDFREUND_SIMULATION', 'false').lower() in ('true', '1', 'yes')
+    if simulation_mode:
+        rosys.enter_simulation()
+
     config = config_from_file('/workspace/src/devkit_launch/config/feldfreund.py')
     system = System(config)
     api.Online()

--- a/devkit_launch/launch/devkit_driver.launch.py
+++ b/devkit_launch/launch/devkit_driver.launch.py
@@ -3,8 +3,10 @@
 import os
 
 import ament_index_python.packages
+from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, SetEnvironmentVariable
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
@@ -12,6 +14,7 @@ from launch_ros.actions import Node
 def generate_launch_description():
     """Generate launch description for devkit driver."""
     config_file = LaunchConfiguration('config_file')
+    simulation = LaunchConfiguration('simulation')
 
     config_directory = os.path.join(
         ament_index_python.packages.get_package_share_directory(
@@ -23,14 +26,34 @@ def generate_launch_description():
         default_value=os.path.join(config_directory, 'devkit.yaml')
     )
 
+    simulation_launch_arg = DeclareLaunchArgument(
+        'simulation',
+        default_value='false',
+        description='Run in simulation mode (true/false)'
+    )
+
+    # Set environment variable for simulation mode
+    set_simulation_env = SetEnvironmentVariable(
+        'FELDFREUND_SIMULATION',
+        simulation
+    )
+
+    # DevKit driver node
+    devkit_driver_node = Node(
+        package='devkit_driver',
+        executable='devkit_driver_node',
+        name='controller',
+        parameters=[
+            config_file,
+            {'use_sim_time': simulation}  # Enable ROS2 simulation time
+        ],
+        respawn=True,
+        respawn_delay=5,
+    )
+
     return LaunchDescription([
         config_file_launch_arg,
-        Node(
-            package='devkit_driver',
-            executable='devkit_driver_node',
-            name='controller',
-            parameters=[config_file],
-            respawn=True,
-            respawn_delay=5,
-        )
+        simulation_launch_arg,
+        set_simulation_env,
+        devkit_driver_node,
     ])

--- a/devkit_launch/launch/devkit_driver.launch.py
+++ b/devkit_launch/launch/devkit_driver.launch.py
@@ -3,10 +3,8 @@
 import os
 
 import ament_index_python.packages
-from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, SetEnvironmentVariable
-from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.actions import DeclareLaunchArgument, SetEnvironmentVariable
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 

--- a/devkit_launch/launch/devkit_simulation.launch.py
+++ b/devkit_launch/launch/devkit_simulation.launch.py
@@ -1,0 +1,52 @@
+"""Main launch file for the devkit project without cameras."""
+# pylint: disable=duplicate-code
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription, TimerAction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    """Generate launch description for the complete devkit system without cameras."""
+    pkg_dir = get_package_share_directory('devkit_launch')
+
+
+    # Include the devkit driver launch file
+    devkit_driver_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(pkg_dir, 'launch', 'devkit_driver.launch.py')
+        ),
+        launch_arguments={'simulation': 'true'}.items()
+    )
+
+    # Include the UI launch file
+    ui_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(pkg_dir, 'launch', 'ui.launch.py')
+        )
+    )
+
+    # Foxglove Bridge Node (delayed to ensure robot_description is published)
+    foxglove_bridge = Node(
+        package='foxglove_bridge',
+        executable='foxglove_bridge',
+        name='foxglove_bridge',
+        parameters=[{
+            'port': 8765,
+            'address': '0.0.0.0',  # Allow external connections
+            'tls': False,
+            'compression': 'jpeg',  # Use JPEG compression for images
+            'jpeg_quality': 75,
+            'max_qos_depth': 10,
+        }],
+    )
+
+    return LaunchDescription([
+        devkit_driver_launch,
+        ui_launch,
+        foxglove_bridge,
+    ])

--- a/devkit_launch/launch/devkit_simulation.launch.py
+++ b/devkit_launch/launch/devkit_simulation.launch.py
@@ -1,19 +1,18 @@
-"""Main launch file for the devkit project without cameras."""
+"""Launch file for the devkit project in simulation mode (driver + UI + Foxglove)."""
 # pylint: disable=duplicate-code
 
 import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription, TimerAction
+from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
-    """Generate launch description for the complete devkit system without cameras."""
+    """Generate launch description for the devkit system in simulation mode."""
     pkg_dir = get_package_share_directory('devkit_launch')
-
 
     # Include the devkit driver launch file
     devkit_driver_launch = IncludeLaunchDescription(
@@ -30,7 +29,7 @@ def generate_launch_description():
         )
     )
 
-    # Foxglove Bridge Node (delayed to ensure robot_description is published)
+    # Foxglove Bridge Node
     foxglove_bridge = Node(
         package='foxglove_bridge',
         executable='foxglove_bridge',

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,7 +21,31 @@ services:
     environment:
       - ROS_DOMAIN_ID=0 # Default ROS domain
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp # Using CycloneDDS
+      - FELDFREUND_SIMULATION=true # Run in simulation mode
 
     # Source and launch the devkit system
     command: bash -c "source /opt/ros/jazzy/setup.bash && source /workspace/install/setup.bash && ros2 launch devkit_launch devkit_nocams.launch.py & tail -f /dev/null"
     restart: unless-stopped
+
+  devkit-simulation:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    image: devkit_ros:latest
+    # network_mode: host # Only works on Linux; commented out for macOS/Windows compatibility
+    privileged: true # Required for hardware access
+    ports:
+      - "80:80" # UI port
+      - "8765:8765" # Foxglove Bridge (if enabled)
+    volumes:
+      - ~/.ros:/root/.ros # For ROS logs
+      - ../:/workspace/src
+    environment:
+      - ROS_DOMAIN_ID=0 # Default ROS domain
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp # Using CycloneDDS
+      - FELDFREUND_SIMULATION=true # Run in simulation mode
+
+    # Source and launch the devkit system
+    command: bash -c "source /opt/ros/jazzy/setup.bash && source /workspace/install/setup.bash && ros2 launch devkit_launch devkit_simulation.launch.py"
+    restart: unless-stopped
+    

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,7 +21,6 @@ services:
     environment:
       - ROS_DOMAIN_ID=0 # Default ROS domain
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp # Using CycloneDDS
-      - FELDFREUND_SIMULATION=true # Run in simulation mode
 
     # Source and launch the devkit system
     command: bash -c "source /opt/ros/jazzy/setup.bash && source /workspace/install/setup.bash && ros2 launch devkit_launch devkit_nocams.launch.py & tail -f /dev/null"
@@ -48,4 +47,3 @@ services:
     # Source and launch the devkit system
     command: bash -c "source /opt/ros/jazzy/setup.bash && source /workspace/install/setup.bash && ros2 launch devkit_launch devkit_simulation.launch.py"
     restart: unless-stopped
-    

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ module = [
     "geometry_msgs.*",
     "nav_msgs.*",
     "gps_msgs.*",
+    "rosgraph_msgs.*",
     "tf2_ros.*",
     "pyquaternion",
 ]
@@ -59,6 +60,7 @@ ignored-modules = [
     "ament_index_python",
     "tf2_ros",
     "gps_msgs",
+    "rosgraph_msgs",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
### Motivation

So far the `devkit_driver_node` ran exclusively against real hardware
(`FeldfreundHardware`) and aborted on startup with an assertion when no hardware
was present. There was no way to run the stack without a physical robot, which is
needed for development, testing and demos.

This PR builds on the idea and implementation by @felixwrz 
(`add rosys simulation to ros node`) and makes the node simulation-capable.

### Implementation

- **Simulation detection in the node** (`devkit_driver_node.py`): `on_startup()`
  reads the `FELDFREUND_SIMULATION` environment variable and calls
  `rosys.enter_simulation()` when it is `true`. The node now distinguishes between
  `FeldfreundHardware` and `FeldfreundSimulation` (instead of hard-asserting on
  hardware) and raises a `TypeError` for an unknown type.
- **Simulated time**: in simulation mode `use_sim_time=True` is set and the RoSys
  time is published to the ROS2 `/clock` topic via `rosys.on_repeat` (100 Hz).
- **Launch**: `devkit_driver.launch.py` gains a `simulation` argument that sets the
  environment variable and forwards `use_sim_time`. A new
  `devkit_simulation.launch.py` starts the driver (with `simulation:=true`), the UI
  and the Foxglove bridge.
- **Docker**: new `devkit-simulation` compose service (ports 80 UI / 8765 Foxglove)
  that runs the simulation launch file.

### Testing

Tested in the `devkit-simulation` container on a clean branch freshly based on
`main`:

- Node starts cleanly in simulation mode ("Running in simulation mode").
- `/clock` publishes simulated time; UI reachable on :80, Foxglove bridge on :8765.
- Control loop verified: `/cmd_vel` (0.3 m/s, 0.2 rad/s) → `/odom` responds
  correctly (position integrates, twist mirrors the command).

Also found during review and fixed in this PR: `FELDFREUND_SIMULATION=true` was
accidentally set on the hardware `devkit` service too (which would have booted real
hardware in simulation mode), plus a few unused launch imports.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will...".
- [x] I chose meaningful labels (if GitHub allows me to do so).
- [x] The implementation is complete.
- [x] Tests with real hardware have been successful (pending; simulation tested successfully).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
