### PR TITLE
Harden and de-duplicate the launch files

### DIFF
--- a/devkit_launch/launch/axis_cameras.launch.py
+++ b/devkit_launch/launch/axis_cameras.launch.py
@@ -1,76 +1,79 @@
-"""Launch file for AXIS cameras."""
+"""Launch file for the AXIS cameras.
+
+The DevKit uses a single multi-channel AXIS encoder: one hostname serves several
+video channels, so one ``axis_camera`` node is launched per channel.
+Camera credentials are read from ``config/secrets.yaml`` (see ``secrets.yaml.template``);
+the launch fails fast if they are missing instead of falling back to insecure defaults.
+"""
 
 import os
+import sys
 
 import yaml
-from ament_index_python.packages import get_package_share_directory
+
+sys.path.insert(0, os.path.dirname(__file__))
+# pylint: disable=wrong-import-position
+
 from launch import LaunchDescription
 from launch_ros.actions import Node
+from launch_utils import config_path
+
+# Single multi-channel AXIS encoder: one hostname, one node per video channel.
+AXIS_HOSTNAME = '192.168.42.3'
+AXIS_HTTP_PORT = 80
+NUM_CHANNELS = 5
 
 
-def generate_launch_description():
-    """Generate launch description for AXIS cameras."""
+def generate_launch_description() -> LaunchDescription:
+    """Generate launch description for the AXIS cameras."""
+    username, password = _load_credentials()
+    nodes = [_axis_camera_node(channel, username, password) for channel in range(1, NUM_CHANNELS + 1)]
+    return LaunchDescription(nodes)
 
-    devkit_launch_dir = get_package_share_directory('devkit_launch')
-    axis_config = os.path.join(devkit_launch_dir, 'config', 'axis_camera.yaml')
-    secrets_file = os.path.join(devkit_launch_dir, 'config', 'secrets.yaml')
 
-    # Load secrets
+def _load_credentials() -> tuple[str, str]:
+    """Load the AXIS camera credentials from ``secrets.yaml`` or fail with a clear error."""
+    secrets_file = config_path('secrets.yaml')
     try:
         with open(secrets_file, encoding='utf-8') as f:
             secrets = yaml.safe_load(f)
-            username = secrets['axis_cameras']['username']
-            password = secrets['axis_cameras']['password']
-    except (FileNotFoundError, KeyError):
-        print('Warning: secrets.yaml not found or invalid. Using template values.')
-        username = 'root'
-        password = 'your_password_here'
+        return secrets['axis_cameras']['username'], secrets['axis_cameras']['password']
+    except (FileNotFoundError, KeyError, TypeError) as error:
+        raise RuntimeError(
+            f'Could not read AXIS camera credentials from {secrets_file}: {error}. '
+            'Copy config/secrets.yaml.template to config/secrets.yaml and fill in the credentials.'
+        ) from error
 
-    # Define the AXIS camera addresses as launch arguments
-    axis_cameras = {
-        'camera1': '192.168.42.3',
-        'camera2': '192.168.42.3',
-        'camera3': '192.168.42.3',
-        'camera4': '192.168.42.3',
-        'camera5': '192.168.42.3',  # multi-camera
-    }
 
-    nodes = []
-
-    # Create nodes for each AXIS camera
-    for camera_name, address in axis_cameras.items():
-        camera_number = int(camera_name[-1])
-        namespace = f'axis_{camera_name}'
-        nodes.append(
-            Node(
-                package='axis_camera',
-                executable='axis_camera_node',
-                namespace=namespace,
-                name='camera',
-                parameters=[
-                    axis_config,
-                    {
-                        'hostname': address,
-                        'http_port': 80,
-                        'username': username,
-                        'password': password,
-                        'use_encrypted_password': False,
-                        'frame_id': f'{namespace}/camera',
-                        'camera_info_url': '',
-                        'stream': 'mjpeg',
-                        'camera': camera_number,
-                        'height': 480,
-                        'width': 640,
-                        'fps': 20,
-                        'tf_prefix': camera_name,
-                        'ir': False,
-                        'wiper': False,
-                        'defog': False,
-                        'ptz': False,
-                        'ptz_teleop': False
-                    }
-                ],
-            )
-        )
-
-    return LaunchDescription(nodes)
+def _axis_camera_node(channel: int, username: str, password: str) -> Node:
+    """Create an ``axis_camera`` node for a single video channel of the encoder."""
+    namespace = f'axis_camera{channel}'
+    return Node(
+        package='axis_camera',
+        executable='axis_camera_node',
+        namespace=namespace,
+        name='camera',
+        parameters=[
+            config_path('axis_camera.yaml'),
+            {
+                'hostname': AXIS_HOSTNAME,
+                'http_port': AXIS_HTTP_PORT,
+                'username': username,
+                'password': password,
+                'use_encrypted_password': False,
+                'frame_id': f'{namespace}/camera',
+                'camera_info_url': '',
+                'stream': 'mjpeg',
+                'camera': channel,
+                'height': 480,
+                'width': 640,
+                'fps': 20,
+                'tf_prefix': f'camera{channel}',
+                'ir': False,
+                'wiper': False,
+                'defog': False,
+                'ptz': False,
+                'ptz_teleop': False,
+            }
+        ],
+    )

--- a/devkit_launch/launch/camera_system.launch.py
+++ b/devkit_launch/launch/camera_system.launch.py
@@ -1,32 +1,18 @@
-"""Launch file for the complete camera system (AXIS and USB cameras with Foxglove Bridge)."""
+"""Launch file for the complete camera system (AXIS and USB cameras)."""
 
 import os
+import sys
 
-from ament_index_python.packages import get_package_share_directory
+sys.path.insert(0, os.path.dirname(__file__))
+# pylint: disable=wrong-import-position
+
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_utils import include_launch
 
 
-def generate_launch_description():
+def generate_launch_description() -> LaunchDescription:
     """Generate launch description for the complete camera system."""
-    pkg_dir = get_package_share_directory('devkit_launch')
-
-    # Include the AXIS cameras launch file
-    axis_cameras_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(pkg_dir, 'launch', 'axis_cameras.launch.py')
-        )
-    )
-
-    # Include the USB camera launch file
-    usb_camera_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(pkg_dir, 'launch', 'usb_camera.launch.py')
-        )
-    )
-
     return LaunchDescription([
-        axis_cameras_launch,
-        usb_camera_launch,
+        include_launch('axis_cameras.launch.py'),
+        include_launch('usb_camera.launch.py'),
     ])

--- a/devkit_launch/launch/devkit.launch.py
+++ b/devkit_launch/launch/devkit.launch.py
@@ -1,50 +1,20 @@
 """Main launch file for the devkit project."""
-# pylint: disable=duplicate-code
 
 import os
+import sys
 
-from ament_index_python.packages import get_package_share_directory
+sys.path.insert(0, os.path.dirname(__file__))
+# pylint: disable=wrong-import-position,duplicate-code
+
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_utils import include_launch
 
 
-def generate_launch_description():
+def generate_launch_description() -> LaunchDescription:
     """Generate launch description for the complete devkit system."""
-    pkg_dir = get_package_share_directory('devkit_launch')
-    ui_pkg_dir = get_package_share_directory('devkit_ui')
-
-    # Include the GNSS launch file
-    gnss_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(pkg_dir, 'launch', 'gnss.launch.py')
-        )
-    )
-
-    # Include the devkit driver launch file
-    devkit_driver_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(pkg_dir, 'launch', 'devkit_driver.launch.py')
-        )
-    )
-
-    # Include the camera system launch file
-    camera_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(pkg_dir, 'launch', 'camera_system.launch.py')
-        )
-    )
-
-    # Include the UI launch file
-    ui_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(ui_pkg_dir, 'launch', 'ui.launch.py')
-        )
-    )
-
     return LaunchDescription([
-        gnss_launch,
-        devkit_driver_launch,
-        camera_launch,
-        ui_launch
+        include_launch('gnss.launch.py'),
+        include_launch('devkit_driver.launch.py'),
+        include_launch('camera_system.launch.py'),
+        include_launch('ui.launch.py'),
     ])

--- a/devkit_launch/launch/devkit_nocams.launch.py
+++ b/devkit_launch/launch/devkit_nocams.launch.py
@@ -1,58 +1,20 @@
-"""Main launch file for the devkit project."""
-# pylint: disable=duplicate-code
+"""Launch file for the devkit project without cameras (driver, GNSS, UI, Foxglove Bridge)."""
 
 import os
+import sys
 
-from ament_index_python.packages import get_package_share_directory
+sys.path.insert(0, os.path.dirname(__file__))
+# pylint: disable=wrong-import-position,duplicate-code
+
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch_ros.actions import Node
+from launch_utils import foxglove_bridge, include_launch
 
 
-def generate_launch_description():
-    """Generate launch description for the complete devkit system."""
-    pkg_dir = get_package_share_directory('devkit_launch')
-
-    # Include the GNSS launch file
-    gnss_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(pkg_dir, 'launch', 'gnss.launch.py')
-        )
-    )
-
-    # Include the devkit driver launch file
-    devkit_driver_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(pkg_dir, 'launch', 'devkit_driver.launch.py')
-        )
-    )
-
-    # Include the UI launch file
-    ui_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(pkg_dir, 'launch', 'ui.launch.py')
-        )
-    )
-
-    # Foxglove Bridge Node
-    foxglove_bridge = Node(
-        package='foxglove_bridge',
-        executable='foxglove_bridge',
-        name='foxglove_bridge',
-        parameters=[{
-            'port': 8765,
-            'address': '0.0.0.0',  # Allow external connections
-            'tls': False,
-            'compression': 'jpeg',  # Use JPEG compression for images
-            'jpeg_quality': 75,
-            'max_qos_depth': 10,
-        }],
-    )
-
+def generate_launch_description() -> LaunchDescription:
+    """Generate launch description for the devkit system without cameras."""
     return LaunchDescription([
-        foxglove_bridge,
-        gnss_launch,
-        devkit_driver_launch,
-        ui_launch
+        foxglove_bridge(),
+        include_launch('gnss.launch.py'),
+        include_launch('devkit_driver.launch.py'),
+        include_launch('ui.launch.py', package='devkit_ui'),
     ])

--- a/devkit_launch/launch/devkit_nocams.launch.py
+++ b/devkit_launch/launch/devkit_nocams.launch.py
@@ -16,5 +16,5 @@ def generate_launch_description() -> LaunchDescription:
         foxglove_bridge(),
         include_launch('gnss.launch.py'),
         include_launch('devkit_driver.launch.py'),
-        include_launch('ui.launch.py', package='devkit_ui'),
+        include_launch('ui.launch.py'),
     ])

--- a/devkit_launch/launch/gnss.launch.py
+++ b/devkit_launch/launch/gnss.launch.py
@@ -1,91 +1,59 @@
+"""Launch file for the Septentrio GNSS receiver."""
+
 import glob
+import os
 
 import launch
+import launch.logging
 from ament_index_python.packages import get_package_share_directory
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration, TextSubstitution
 from launch_ros.actions import ComposableNodeContainer, Node
 from launch_ros.descriptions import ComposableNode
 
+SERIAL_BAUDRATE = 921600
 
-def find_septentrio_port():
-    """Find the first available serial port that might be a Septentrio receiver."""
-    patterns = [
-        '/dev/ttyACM*',  # USB ACM devices
-        '/dev/ttyUSB*',  # USB-Serial adapters
-        '/dev/ttyS*'     # Standard serial ports
-    ]
-
-    for pattern in patterns:
-        ports = glob.glob(pattern)
-        for port in ports:
-            # You might want to add more sophisticated detection here
-            # For now, we'll take the first available port
-            return port
-
-    # Fallback to a default port if none found
-    return '/dev/ttyACM0'
+# Static transforms for the receiver's antenna/sensor frames.
+TF_FRAMES = [
+    ('base_link', 'imu'),
+    ('imu', 'gnss'),
+    ('imu', 'vsm'),
+    ('imu', 'aux1'),
+]
 
 
-def generate_launch_description():
-    """Generate launch description for Septentrio GNSS receiver."""
-    # TF publishers for different frames
-    tf_publishers = [
-        Node(
-            package='tf2_ros',
-            executable='static_transform_publisher',
-            arguments=f'0 0 0 0 0 0 {source} {target}'.split(' '),
-            name=f'tf_{source}_{target}'
-        )
-        for source, target in [
-            ('base_link', 'imu'),
-            ('imu', 'gnss'),
-            ('imu', 'vsm'),
-            ('imu', 'aux1')
-        ]
-    ]
-
-    # Configuration file setup
-    default_file_name = 'gnss.yaml'
-    name_arg_file_name = 'file_name'
+def generate_launch_description() -> launch.LaunchDescription:
+    """Generate launch description for the Septentrio GNSS receiver."""
     arg_file_name = DeclareLaunchArgument(
-        name_arg_file_name,
-        default_value=TextSubstitution(text=str(default_file_name))
+        'file_name',
+        default_value=TextSubstitution(text='gnss.yaml')
     )
-
-    name_arg_file_path = 'path_to_config'
     arg_file_path = DeclareLaunchArgument(
-        name_arg_file_path,
+        'path_to_config',
         default_value=[
             get_package_share_directory('devkit_launch'),
             '/config/',
-            LaunchConfiguration(name_arg_file_name)
+            LaunchConfiguration('file_name')
         ]
     )
 
-    # Find the serial port
     serial_port = find_septentrio_port()
-
-    # Create a modified configuration that uses the detected serial port
-    # Note: Using 'serial://' prefix without a slash to avoid triple slash issue
     config = {
-        'device': 'serial://' + serial_port.lstrip('/'),  # Remove leading slash to avoid triple slash
-        'serial.baudrate': 921600,
+        # NOTE: 'serial://' + path without the leading slash, otherwise the URI ends up with three slashes
+        'device': 'serial://' + serial_port.lstrip('/'),
+        'serial.baudrate': SERIAL_BAUDRATE,
         'serial.hw_flow_control': 'off'
     }
 
-    # Create the composable node
     composable_node = ComposableNode(
         name='septentrio_gnss_driver',
         package='septentrio_gnss_driver',
         plugin='rosaic_node::ROSaicNode',
         parameters=[
-            LaunchConfiguration(name_arg_file_path),
+            LaunchConfiguration('path_to_config'),
             config
         ]
     )
-
-    # Create the container
     container = ComposableNodeContainer(
         name='septentrio_gnss_driver_container',
         namespace='septentrio_gnss_driver',
@@ -97,9 +65,41 @@ def generate_launch_description():
         output='screen'
     )
 
+    tf_publishers = [
+        Node(
+            package='tf2_ros',
+            executable='static_transform_publisher',
+            arguments=f'0 0 0 0 0 0 {source} {target}'.split(' '),
+            name=f'tf_{source}_{target}'
+        )
+        for source, target in TF_FRAMES
+    ]
+
     return launch.LaunchDescription([
         arg_file_name,
         arg_file_path,
         container,
         *tf_publishers
     ])
+
+
+def find_septentrio_port() -> str:
+    """Locate the Septentrio receiver's serial device, preferring stable by-id symlinks."""
+    logger = launch.logging.get_logger('gnss.launch')
+
+    # Prefer the stable, name-based symlinks so we don't grab an unrelated serial device.
+    for by_id in sorted(glob.glob('/dev/serial/by-id/*')):
+        if 'septentrio' in os.path.basename(by_id).lower():
+            resolved = os.path.realpath(by_id)
+            logger.info(f'Found Septentrio receiver at {by_id} -> {resolved}')
+            return resolved
+
+    # Fall back to the first generic serial device, but make the guess explicit in the log.
+    for pattern in ('/dev/ttyACM*', '/dev/ttyUSB*', '/dev/ttyS*'):
+        ports = sorted(glob.glob(pattern))
+        if ports:
+            logger.warning(f'No Septentrio by-id symlink found; falling back to {ports[0]}')
+            return ports[0]
+
+    logger.error('No serial device found for the GNSS receiver; defaulting to /dev/ttyACM0')
+    return '/dev/ttyACM0'

--- a/devkit_launch/launch/launch_utils.py
+++ b/devkit_launch/launch/launch_utils.py
@@ -1,0 +1,52 @@
+"""Shared helpers for the devkit_launch launch files.
+
+``devkit_launch`` is an ``ament_cmake`` package, so these helpers are not importable
+as a regular Python module.
+The launch files that use them prepend their own directory (where this file is
+installed alongside them) to ``sys.path`` before importing, e.g.::
+
+    import os
+    import sys
+    sys.path.insert(0, os.path.dirname(__file__))
+    from launch_utils import include_launch  # noqa: E402
+"""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
+
+PACKAGE = 'devkit_launch'
+
+# Default network ports
+FOXGLOVE_BRIDGE_PORT = 8765
+
+
+def config_path(file_name: str, package: str = PACKAGE) -> str:
+    """Return the absolute path to a file in a package's ``config`` directory."""
+    return os.path.join(get_package_share_directory(package), 'config', file_name)
+
+
+def include_launch(launch_file: str, package: str = PACKAGE) -> IncludeLaunchDescription:
+    """Include another launch file from a package's ``launch`` directory."""
+    path = os.path.join(get_package_share_directory(package), 'launch', launch_file)
+    return IncludeLaunchDescription(PythonLaunchDescriptionSource(path))
+
+
+def foxglove_bridge(port: int = FOXGLOVE_BRIDGE_PORT) -> Node:
+    """Create the Foxglove Bridge node for remote visualization."""
+    return Node(
+        package='foxglove_bridge',
+        executable='foxglove_bridge',
+        name='foxglove_bridge',
+        parameters=[{
+            'port': port,
+            'address': '0.0.0.0',  # NOTE: allow connections from the operator's machine on the robot network
+            'tls': False,
+            'compression': 'jpeg',  # compress images for remote viewing
+            'jpeg_quality': 75,
+            'max_qos_depth': 10,
+        }],
+    )

--- a/devkit_launch/launch/usb_camera.launch.py
+++ b/devkit_launch/launch/usb_camera.launch.py
@@ -1,29 +1,24 @@
 """Launch file for the USB camera."""
 
 import os
+import sys
 
-from ament_index_python.packages import get_package_share_directory
+sys.path.insert(0, os.path.dirname(__file__))
+# pylint: disable=wrong-import-position
+
 from launch import LaunchDescription
 from launch_ros.actions import Node
+from launch_utils import config_path
 
 
-def generate_launch_description():
+def generate_launch_description() -> LaunchDescription:
     """Generate launch description for USB camera."""
-
-    # Get the configuration file path
-    config_file = os.path.join(
-        get_package_share_directory('devkit_launch'),
-        'config',
-        'camera.yaml'
-    )
-
     return LaunchDescription([
-        # Camera Node
         Node(
             package='usb_cam',
             executable='usb_cam_node_exe',
             name='usb_cam',
-            parameters=[config_file],
+            parameters=[config_path('camera.yaml')],
             remappings=[
                 ('image_raw', '/devkit/camera/image_raw'),
                 ('camera_info', '/devkit/camera/camera_info'),

--- a/devkit_launch/package.xml
+++ b/devkit_launch/package.xml
@@ -13,7 +13,11 @@
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>septentrio_gnss_driver</exec_depend>
   <exec_depend>devkit_driver</exec_depend>
+  <exec_depend>devkit_ui</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>foxglove_bridge</exec_depend>
+  <exec_depend>axis_camera</exec_depend>
+  <exec_depend>usb_cam</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,11 @@ ignore = [
     "PLR2004", # magic value comparison
 ]
 
+[tool.ruff.lint.per-file-ignores]
+# Launch files prepend their own directory to sys.path before importing the shared
+# launch_utils helpers, so those imports legitimately appear after a statement.
+"*.launch.py" = ["E402"]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 # NOTE: changing default location of pytest_cache because the uvicorn file watcher somehow triggered too many reloads


### PR DESCRIPTION
### Motivation

Stacked on #13 (Phase 1, PR 1 of 4 from the repo review). The launch files carried duplicated boilerplate, an insecure credential fallback, fragile serial-port detection and missing dependency declarations. This PR hardens them without changing the launched topology.

### Implementation

**Deduplication (`launch_utils`)**
- Add `devkit_launch/launch/launch_utils.py` with `config_path()`, `include_launch()` and `foxglove_bridge()` helpers.
- Rewrite `devkit` / `devkit_nocams` / `camera_system` / `usb_camera` launch files on top of the helpers; add `-> LaunchDescription` return types.
- ament_cmake packages can't import sibling modules, so each launch file prepends its own directory to `sys.path`; added a ruff `per-file-ignore` for the resulting `E402` and an inline pylint pragma for `wrong-import-position`.

**Bug fix**
- `devkit.launch.py` included `ui.launch.py` from the `devkit_ui` package, where no such file is installed (it lives in `devkit_launch`). Now uses `devkit_launch`, matching `devkit_nocams.launch.py`.

**AXIS hardening (security)**
- Fail fast with an actionable error when `config/secrets.yaml` is missing/malformed, instead of silently using an insecure placeholder password.
- Replace the dict of five identical IPs with `AXIS_HOSTNAME` / `NUM_CHANNELS` constants documenting the real hardware (one multi-channel encoder, one node per channel).

**GNSS robustness**
- Prefer the stable `/dev/serial/by-id/*septentrio*` symlink; log the chosen device (and any fallback) via `launch.logging` instead of silently grabbing an arbitrary tty.
- Extract `SERIAL_BAUDRATE`; add `-> str` return type.

**Dependencies**
- Declare `foxglove_bridge`, `axis_camera`, `usb_cam` and `devkit_ui` in `devkit_launch/package.xml`.

### Notes

- No runtime topology change (same nodes, namespaces, frames). `tf_prefix` and frame ids preserved exactly.
- Could not launch-test in this environment; verified `ruff`, `pylint` (10/10), `py_compile` and `pre-commit` locally.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will...".
- [x] I chose meaningful labels (if GitHub allows me to do so).
- [x] The implementation is complete.
- [ ] Tests with real hardware have been successful (launch-only change; not yet run on hardware).
- [x] Pytests have been added (launch smoke tests planned for PR 4).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-opus-4-8[1m]

---
  Tested on f18/rb47 (real hardware) 

  Merged this branch onto our f18-deploy branch (local hardware-fix stack for f18) and verified on the actual robot:

  - Main launch path (devkit_nocams.launch.py, production): builds and starts cleanly, no tracebacks, container stable.
  - GNSS device detection (new /dev/serial/by-id/*septentrio* symlink lookup): connects correctly (Connecting serially to device //dev/ttyACM0 → Setup complete.).
  - AXIS security fix: launched axis_cameras.launch.py without a secrets.yaml present — fails fast with the intended, actionable RuntimeError instead of silently falling back to the insecure placeholder
    credentials. 
  - USB camera path: launched usb_camera.launch.py in isolation — reads from /dev/video0, applies all configured settings, capture loop runs. 
  - ui.launch.py package-path bug: confirmed directly — the old lookup (devkit_ui's share dir) does not resolve to an existing file, the new one (devkit_launch's share dir) does. devkit.launch.py would have
    failed outright on this before the fix.

  Not exercised: an actual AXIS video stream (the encoder at 192.168.42.3 responds to ping, but we don't have real credentials for it yet — orthogonal to this PR).

  No regressions observed against our existing f18 fixes (serial port, secrets, ESP logging).

