### PR TITLE
Add a pytest/ROS test foundation and verify the Lizard download

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,20 @@ jobs:
         run: pip install -r requirements-dev.txt
       - name: ${{ matrix.tools.command }}
         run: ${{ matrix.tools.command }}
+
+  ros-tests:
+    # ROS packages (rclpy, message types) are not on PyPI, so the tests run inside a
+    # ROS image instead of the pip-only code-checks job above.
+    runs-on: ubuntu-latest
+    container: ros:jazzy
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: install dependencies
+        run: |
+          apt-get update && apt-get install -y python3-pip git libgl1 libglib2.0-0
+          pip install --break-system-packages --ignore-installed -r requirements-dev.txt
+      - name: run pytest
+        run: |
+          . /opt/ros/jazzy/setup.sh
+          make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: install dependencies
         run: |
-          apt-get update && apt-get install -y python3-pip git libgl1 libglib2.0-0
+          apt-get update && apt-get install -y \
+            python3-pip git libgl1 libglib2.0-0 \
+            ros-jazzy-geometry-msgs ros-jazzy-nav-msgs ros-jazzy-sensor-msgs \
+            ros-jazzy-std-msgs ros-jazzy-rosgraph-msgs ros-jazzy-tf2-ros
           pip install --break-system-packages --ignore-installed -r requirements-dev.txt
       - name: run pytest
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help sync install-ci mypy pylint pre-commit
+.PHONY: help sync install-ci mypy pylint ruff test pre-commit
 
 default: help
 
@@ -30,6 +30,13 @@ pylint:
 ## ruff		Run ruff code analysis.
 ruff:
 	ruff check ./devkit_driver/devkit_driver ./devkit_launch/launch ./devkit_ui/devkit_ui
+
+## test		Run the pytest suite (requires a sourced ROS environment).
+# NOTE: the ROS launch_testing pytest plugins are incompatible with modern pytest, so we
+# disable plugin autoloading and explicitly load only pytest-asyncio (for asyncio_mode).
+test:
+	PYTHONPATH=$(CURDIR)/devkit_driver:$(CURDIR)/devkit_ui:$$PYTHONPATH \
+	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin
 
 ## pre-commit	Run pre-commit hooks on all files.
 pre-commit:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,9 @@ RUN apt-get update && apt-get install -y \
 RUN mkdir -p /root/.lizard && \
     cd /root && \
     LIZARD_VERSION=v0.9.0 && \
+    LIZARD_SHA256=eba9c9a62a4be52e3917aa9ecfdb08218df8da9ac8fcca115c694a236cc22c8c && \
     wget https://github.com/zauberzeug/lizard/releases/download/${LIZARD_VERSION}/lizard_firmware_and_devtools_${LIZARD_VERSION}_esp32.zip && \
+    echo "${LIZARD_SHA256}  lizard_firmware_and_devtools_${LIZARD_VERSION}_esp32.zip" | sha256sum -c - && \
     unzip lizard_firmware_and_devtools_${LIZARD_VERSION}_esp32.zip -d /root/.lizard && \
     chmod +x /root/.lizard/espresso.py && \
     cd /root/.lizard && \

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,27 @@
+"""Import smoke tests for the driver handler modules.
+
+They guard against the dependency/API breakage that the rosys / feldfreund_devkit
+migration can introduce. A ROS environment is required (the modules import rclpy and
+the ROS message packages), so these run in the ``ros-tests`` CI job, not the pip-only
+``code-checks`` jobs. Importing the modules at collection time is the actual check.
+"""
+
+from devkit_driver.qos import SAFETY_QOS
+
+from devkit_driver import modules
+
+
+def test_qos_profile_is_configured() -> None:
+    assert SAFETY_QOS.depth == 1
+
+
+def test_all_handler_modules_import() -> None:
+    handlers = (
+        modules.BMSHandler,
+        modules.BumperHandler,
+        modules.EStopHandler,
+        modules.OdomHandler,
+        modules.RobotBrainHandler,
+        modules.TwistHandler,
+    )
+    assert all(handler is not None for handler in handlers)


### PR DESCRIPTION
### Motivation

Stacked on #13 (Phase 1, PR 4 of 4 from the repo review). There was no test suite and nowhere for ROS tests to run (the existing CI is pip-only). This adds the test foundation and hardens the Docker build.

### Implementation

- **Dockerfile**: pin and verify the SHA256 of the Lizard firmware/devtools zip after download, so a corrupted or tampered release fails the build instead of installing silently.
- **tests/**: add import smoke tests for the driver handler modules. Importing them at collection time catches the dependency/API breakage that the rosys/feldfreund_devkit migration can introduce.
- **Makefile**: add a `make test` target that runs pytest with the package dirs on `PYTHONPATH`.
- **CI**: add a `ros-tests` job that runs inside the `ros:jazzy` image (the pip-only `code-checks` jobs can't provide `rclpy` or the message packages).

### Notes / Assumptions

- This is a **foundation** PR: the first tests are deliberately minimal (import smoke tests). Real handler unit tests and launch smoke tests are follow-ups now that there is a place for them to run.
- The `ros-tests` job is the first CI job that needs a ROS environment; I could not run it locally (no ROS here), so it is verified through CI. If it surfaces a genuine gap (e.g. a runtime dependency missing from `requirements.txt`), that is exactly what the smoke test is for and I will fix it.
- The Dockerfile checksum was computed from the published `v0.9.0` release asset.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will...".
- [x] I chose meaningful labels (if GitHub allows me to do so).
- [x] The implementation is complete.
- [x] Tests with real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-opus-4-8[1m]
