### PR TITLE
Add manual weeding screw control (axes, drive interlock, UI)

### DIFF
--- a/devkit_driver/devkit_driver/devkit_driver_node.py
+++ b/devkit_driver/devkit_driver/devkit_driver_node.py
@@ -16,7 +16,16 @@ from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from rosgraph_msgs.msg import Clock
 
-from devkit_driver.modules import BMSHandler, BumperHandler, EStopHandler, OdomHandler, RobotBrainHandler, TwistHandler
+from devkit_driver.modules import (
+    BMSHandler,
+    BumperHandler,
+    EStopHandler,
+    OdomHandler,
+    RobotBrainHandler,
+    TwistHandler,
+    WeedingScrewHandler,
+)
+from devkit_driver.weeding_screw import WeedingScrew, WeedingScrewConfiguration
 
 
 class DevkitDriver(Node):
@@ -47,6 +56,8 @@ class DevkitDriver(Node):
             self._bumper_handler = BumperHandler(self, self.system.feldfreund.bumper, self.system.feldfreund.estop)
         self._twist_handler = TwistHandler(self, self.system.feldfreund.wheels)
         self._estop_handler = EStopHandler(self, self.system.feldfreund.estop)
+        if isinstance(self.system.feldfreund.implement, WeedingScrew):
+            self._weeding_screw_handler = WeedingScrewHandler(self, self.system.feldfreund.implement)
 
     def _publish_clock(self) -> None:
         """Publish RoSys simulation time to ROS2 /clock topic."""
@@ -84,6 +95,8 @@ def on_startup() -> None:
     secrets = Secrets()
     config = config_from_file(_config_file_path(), secrets=secrets)
     system = System(config, secrets=secrets)
+    if isinstance(config.implement, WeedingScrewConfiguration):
+        system.feldfreund.add_implement(WeedingScrew(config.implement, system.feldfreund))
     api.Online()
     _state.ros_thread = threading.Thread(target=ros_main, args=(system,), name='ros_spin')
     _state.ros_thread.start()

--- a/devkit_driver/devkit_driver/modules/__init__.py
+++ b/devkit_driver/devkit_driver/modules/__init__.py
@@ -4,6 +4,7 @@ from .estop_handler import EStopHandler
 from .odom_handler import OdomHandler
 from .robot_brain_handler import RobotBrainHandler
 from .twist_handler import TwistHandler
+from .weeding_screw_handler import WeedingScrewHandler
 
 __all__ = [
     'BMSHandler',
@@ -12,4 +13,5 @@ __all__ = [
     'OdomHandler',
     'RobotBrainHandler',
     'TwistHandler',
+    'WeedingScrewHandler',
 ]

--- a/devkit_driver/devkit_driver/modules/weeding_screw_handler.py
+++ b/devkit_driver/devkit_driver/modules/weeding_screw_handler.py
@@ -1,0 +1,84 @@
+import asyncio
+from collections.abc import Coroutine
+from typing import Any
+
+import rosys
+from rclpy.node import Node
+from rosys import background_tasks
+from std_msgs.msg import Bool, Empty, Float64
+
+from ..qos import SAFETY_QOS
+from ..weeding_screw import WeedingScrew
+from .base import Handler
+
+
+class WeedingScrewHandler(Handler):
+    """Handle the weeding screw implement: home/clear-view/stop/punch commands and axis status.
+
+    Manual control only, matching feldfreund_devkit_ros' current scope: no camera-based weed
+    targeting or FieldNavigation-driven autonomous weeding here (see the concept doc).
+    """
+
+    def __init__(self, node: Node, weeding_screw: WeedingScrew):
+        super().__init__(node)
+        self._weeding_screw = weeding_screw
+        self._active_task: asyncio.Task | None = None
+        """The currently running home/clear_view/punch task, if any - so stop() can cancel it.
+
+        Without this, stop() only disables the motors for one cycle: the still-running move_to()
+        loop sees ctrl_enable go false, re-enables the motor itself (it wants to reach its target)
+        and continues - stop briefly pauses the axis instead of aborting the move.
+        """
+
+        node.create_subscription(Empty, 'weeding_screw/home', self._handle_home, 10)
+        node.create_subscription(Empty, 'weeding_screw/clear_view', self._handle_clear_view, 10)
+        node.create_subscription(Empty, 'weeding_screw/stop', self._handle_stop, 10)
+        node.create_subscription(Float64, 'weeding_screw/punch', self._handle_punch, 10)
+        node.create_subscription(Float64, 'weeding_screw/set_drill_depth', self._handle_set_drill_depth, 10)
+
+        self._y_position_pub = node.create_publisher(Float64, 'weeding_screw/y_position', 10)
+        self._z_position_pub = node.create_publisher(Float64, 'weeding_screw/z_position', 10)
+        self._is_referenced_pub = node.create_publisher(Bool, 'weeding_screw/is_referenced', SAFETY_QOS)
+        self._alarm_pub = node.create_publisher(Bool, 'weeding_screw/alarm', SAFETY_QOS)
+        self._drill_depth_pub = node.create_publisher(Float64, 'weeding_screw/drill_depth', 10)
+        rosys.on_repeat(self._publish_state, 0.2)
+
+    async def _run_and_log(self, coro: Coroutine[Any, Any, Any], label: str) -> None:
+        await coro
+        self.log.info(f'{label}: done')
+
+    def _run_command(self, coro: Coroutine[Any, Any, Any], label: str, name: str) -> None:
+        if self._active_task is not None and not self._active_task.done():
+            self.log.warning(f'{label}: another weeding screw command is still running, ignoring')
+            return
+        self._active_task = background_tasks.create(self._run_and_log(coro, label), name=name)
+
+    def _handle_home(self, _: Empty) -> None:
+        self._run_command(self._weeding_screw.try_home(), 'Homing weeding screw', 'weeding_screw: home')
+
+    def _handle_clear_view(self, _: Empty) -> None:
+        self._run_command(self._weeding_screw.clear_view(), 'Clearing view', 'weeding_screw: clear_view')
+
+    def _handle_stop(self, _: Empty) -> None:
+        if self._active_task is not None and not self._active_task.done():
+            self._active_task.cancel()
+        background_tasks.create(self._run_and_log(self._weeding_screw.stop(), 'Stopping weeding screw'),
+                                name='weeding_screw: stop')
+
+    def _handle_punch(self, msg: Float64) -> None:
+        self._run_command(self._weeding_screw.punch(msg.data), f'Punching at y={msg.data:.3f}', 'weeding_screw: punch')
+
+    def _handle_set_drill_depth(self, msg: Float64) -> None:
+        self._weeding_screw.drill_depth = msg.data
+        self.log.info(f'Drill depth set to {msg.data:.3f} m')
+
+    def _publish_state(self) -> None:
+        if not self.active:
+            return
+        y_axis = self._weeding_screw.y_axis
+        z_axis = self._weeding_screw.z_axis
+        self._y_position_pub.publish(Float64(data=y_axis.position))
+        self._z_position_pub.publish(Float64(data=z_axis.position))
+        self._is_referenced_pub.publish(Bool(data=y_axis.is_referenced and z_axis.is_referenced))
+        self._alarm_pub.publish(Bool(data=y_axis.alarm or z_axis.alarm))
+        self._drill_depth_pub.publish(Float64(data=self._weeding_screw.drill_depth))

--- a/devkit_driver/devkit_driver/weeding_screw/__init__.py
+++ b/devkit_driver/devkit_driver/weeding_screw/__init__.py
@@ -1,0 +1,18 @@
+from .axis import Axis, AxisSimulation
+from .configuration import WeedingScrewConfiguration, YCanOpenConfiguration, ZCanOpenConfiguration
+from .errors import CanOpenHardwareException
+from .implement import WeedingScrew
+from .y_axis import YAxisCanOpenHardware
+from .z_axis import ZAxisCanOpenHardware
+
+__all__ = [
+    'Axis',
+    'AxisSimulation',
+    'CanOpenHardwareException',
+    'WeedingScrew',
+    'WeedingScrewConfiguration',
+    'YAxisCanOpenHardware',
+    'YCanOpenConfiguration',
+    'ZAxisCanOpenHardware',
+    'ZCanOpenConfiguration',
+]

--- a/devkit_driver/devkit_driver/weeding_screw/axis.py
+++ b/devkit_driver/devkit_driver/weeding_screw/axis.py
@@ -1,0 +1,190 @@
+import abc
+import asyncio
+
+import rosys
+from nicegui import Event
+from rosys.automation import uninterruptible
+
+
+class Axis(rosys.hardware.Module, abc.ABC):
+    """Abstract base class for a linear axis module (steps <-> position, referencing)."""
+
+    def __init__(self, *,
+                 max_speed: int,
+                 reference_speed: int,
+                 min_position: float,
+                 max_position: float,
+                 axis_offset: float,
+                 steps_per_m: float,
+                 reversed_direction: bool,
+                 **kwargs) -> None:
+        super().__init__(**kwargs)
+
+        self.max_speed = max_speed
+        self.reference_speed = reference_speed
+        self.min_position = min_position
+        self.max_position = max_position
+        self.axis_offset = axis_offset
+        self.steps_per_m = steps_per_m
+        self.reversed_direction = reversed_direction
+
+        self.steps: int = 0
+        self._is_referenced: bool = False
+        self.alarm: bool = False
+        self.idle: bool = False
+        self.end_t: bool = False
+        self.end_b: bool = False
+        self.end_l: bool = False
+        self.end_r: bool = False
+
+        self._stop_requested: bool = False
+        """Set by stop(), checked inside move_to()'s poll loop.
+
+        rosys.run.retry(..., max_timeout=...) (used for every move_to() call) runs the move in its
+        own detached asyncio task internally - cancelling the caller's task never reaches it. This
+        flag is the only reliable way for stop() to actually abort an in-progress move, regardless
+        of which task called it.
+        """
+
+        self.REFERENCE_CHANGED: Event[bool] = Event()
+        """Emitted with the new value when the axis gains or loses its reference."""
+
+        rosys.on_shutdown(self.stop)
+
+    @property
+    def is_referenced(self) -> bool:
+        return self._is_referenced
+
+    @is_referenced.setter
+    def is_referenced(self, value: bool) -> None:
+        """Track the reference and announce the edge.
+
+        Referencing is lost from several places (endstop or alarm in the core stream, a raised
+        hardware exception, an aborted reference drive); routing every write through here gives
+        subscribers a single edge to react to. Only actual changes are emitted, so assigning the
+        unchanged value on every core-output frame stays quiet.
+        """
+        if value == self._is_referenced:
+            return
+        self._is_referenced = value
+        self.REFERENCE_CHANGED.emit(value)
+
+    @abc.abstractmethod
+    async def stop(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    async def move_to(self, position: float, speed: int | None = None) -> None:
+        if self.alarm:
+            raise RuntimeError('axis is in alarm state')
+        if speed is None:
+            speed = self.max_speed
+        if not self.is_referenced:
+            raise RuntimeError('axis is not referenced, reference first')
+        if speed > self.max_speed:
+            raise RuntimeError(f'axis speed is too high, max speed is {self.max_speed}')
+        if not self.min_position <= position <= self.max_position:
+            raise RuntimeError(
+                f'target position {position} is out of axis range {self.min_position} to {self.max_position}')
+
+    @abc.abstractmethod
+    async def try_reference(self) -> bool:
+        if self.alarm:
+            return False
+        return True
+
+    @abc.abstractmethod
+    async def reset_fault(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    async def recover(self) -> None:
+        pass
+
+    def compute_steps(self, position: float) -> int:
+        return int((position + self.axis_offset) * self.steps_per_m) * (-1 if self.reversed_direction else 1)
+
+    def compute_position(self, steps: int) -> float:
+        return steps / self.steps_per_m * (-1 if self.reversed_direction else 1) - self.axis_offset
+
+    @property
+    def position(self) -> float:
+        return self.compute_position(self.steps)
+
+    async def return_to_reference(self) -> None:
+        try:
+            await self.move_to(0)
+        except RuntimeError as e:
+            self.log.error('could not return axis to reference because of %s', e)
+
+
+class AxisSimulation(Axis, rosys.hardware.ModuleSimulation):
+    """A simple simulated axis, for exercising the ROS wiring without hardware."""
+
+    def __init__(self, *,
+                 max_speed: int = 80_000,
+                 reference_speed: int = 40,
+                 min_position: float = -0.12,
+                 max_position: float = 0.12,
+                 axis_offset: float = 0.123,
+                 steps_per_m: float = 666.67 * 1000,
+                 reversed_direction: bool = False,
+                 ) -> None:
+        self.speed: int = 0
+        self.target_steps: int | None = None
+        super().__init__(
+            max_speed=max_speed,
+            reference_speed=reference_speed,
+            min_position=min_position,
+            max_position=max_position,
+            axis_offset=axis_offset,
+            steps_per_m=steps_per_m,
+            reversed_direction=reversed_direction,
+        )
+
+    async def stop(self) -> None:
+        self._stop_requested = True
+        self.speed = 0
+        self.target_steps = None
+
+    @uninterruptible
+    async def move_to(self, position: float, speed: int | None = None) -> None:
+        self._stop_requested = False
+        if speed is None:
+            speed = self.max_speed
+        await super().move_to(position, speed)
+        self.target_steps = self.compute_steps(position)
+        self.speed = speed if self.target_steps > self.steps else speed * -1
+        while self.target_steps is not None:
+            await rosys.sleep(0.2)
+        if self._stop_requested:
+            raise asyncio.CancelledError()
+
+    @uninterruptible
+    async def try_reference(self) -> bool:
+        if not await super().try_reference():
+            return False
+        self.steps = 0
+        self.is_referenced = True
+        return True
+
+    async def reset_fault(self) -> None:
+        self.alarm = False
+
+    @uninterruptible
+    async def recover(self) -> None:
+        self.log.debug('recovering axis')
+        await self.reset_fault()
+        if self.alarm:
+            return
+        await self.try_reference()
+
+    async def step(self, dt: float) -> None:
+        await super().step(dt)
+        self.steps += int(dt * self.speed)
+        self.idle = self.speed == 0
+        if self.target_steps is not None:
+            if (self.speed > 0) == (self.steps > self.target_steps):
+                self.steps = self.target_steps
+                self.target_steps = None
+                self.speed = 0

--- a/devkit_driver/devkit_driver/weeding_screw/configuration.py
+++ b/devkit_driver/devkit_driver/weeding_screw/configuration.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass
+
+from feldfreund_devkit.config import ImplementConfiguration
+
+
+@dataclass(slots=True, kw_only=True)
+class YCanOpenConfiguration:
+    """Hardware configuration for the horizontal (Y) axis, driven by a CANopen motor."""
+    name: str
+    can_address: int
+    max_position: float
+    min_position: float
+    axis_offset: float
+    reversed_direction: bool
+    end_left_pin: int
+    end_right_pin: int
+    end_stops_on_expander: bool
+    motor_on_expander: bool
+    end_stops_inverted: bool
+    max_speed: int
+    reference_speed: int
+    steps_per_m: float
+
+
+@dataclass(slots=True, kw_only=True)
+class ZCanOpenConfiguration:
+    """Hardware configuration for the vertical (Z) axis, driven by a CANopen motor."""
+    name: str
+    can_address: int
+    max_position: float
+    min_position: float
+    axis_offset: float
+    reversed_direction: bool
+    end_top_pin: int
+    end_bottom_pin: int
+    end_stops_on_expander: bool
+    motor_on_expander: bool
+    end_stops_inverted: bool
+    max_speed: int
+    reference_speed: int
+    steps_per_m: float
+
+
+@dataclass(kw_only=True)
+class WeedingScrewConfiguration(ImplementConfiguration):
+    """Configuration for the weeding screw implement.
+
+    Only the CANopen axis variant is supported here (f18's actual hardware); the stepper and
+    D1-servo variants that exist in the feldfreund app repo have no ROS-side use case yet.
+
+    Defaults:
+        lizard_name: 'weeding_screw'
+        display_name: 'Weeding Screw'
+        work_radius: 0.025
+    """
+    lizard_name: str = 'weeding_screw'
+    display_name: str = 'Weeding Screw'
+    work_radius: float = 0.025
+    y_axis: YCanOpenConfiguration
+    z_axis: ZCanOpenConfiguration

--- a/devkit_driver/devkit_driver/weeding_screw/errors.py
+++ b/devkit_driver/devkit_driver/weeding_screw/errors.py
@@ -1,0 +1,2 @@
+class CanOpenHardwareException(Exception):
+    """Raised when a CANopen axis reports a hardware fault (alarm, not initialized, not enabled)."""

--- a/devkit_driver/devkit_driver/weeding_screw/implement.py
+++ b/devkit_driver/devkit_driver/weeding_screw/implement.py
@@ -1,0 +1,113 @@
+from functools import partial
+from typing import Any
+
+import rosys
+from feldfreund_devkit import FeldfreundHardware, FeldfreundSimulation, Implement, ImplementException
+from feldfreund_devkit.hardware import TracksHardware
+from rosys.geometry import Point
+
+from .axis import AxisSimulation
+from .configuration import WeedingScrewConfiguration
+from .y_axis import YAxisCanOpenHardware
+from .z_axis import ZAxisCanOpenHardware
+
+
+class WeedingScrew(Implement):
+    """Manual axis control for f18's weeding screw (Y-/Z-axis punch tool).
+
+    Ported from the feldfreund app's WeedingScrew/Axis classes (used there as a template, not
+    imported) with camera-based weed targeting and FieldNavigation-driven autonomous work
+    dropped; only home / clear-view / stop / punch-at-Y-offset are exposed here.
+    """
+
+    DRILL_DEPTH = 0.14
+
+    def __init__(self, config: WeedingScrewConfiguration,
+                 feldfreund: FeldfreundHardware | FeldfreundSimulation) -> None:
+        super().__init__(config)
+        self._config: WeedingScrewConfiguration = config
+        self.y_axis = self._setup_y_axis(feldfreund)
+        self.z_axis = self._setup_z_axis(feldfreund)
+        self.drill_depth: float = self.DRILL_DEPTH
+
+    @property
+    def modules(self) -> list[rosys.hardware.Module]:
+        return [self.y_axis, self.z_axis]
+
+    async def try_home(self) -> bool:
+        if not await rosys.run.retry(self.z_axis.try_reference, max_attempts=2, max_timeout=60.0):
+            return False
+        await rosys.sleep(0.5)
+        return await rosys.run.retry(self.y_axis.try_reference, max_attempts=2, max_timeout=60.0)
+
+    async def clear_view(self) -> None:
+        await rosys.run.retry(self.z_axis.return_to_reference, max_attempts=2, max_timeout=20.0)
+        y = (self.y_axis.min_position + 0.002) if self.y_axis.position <= 0 \
+            else (self.y_axis.max_position - 0.002)
+        await rosys.run.retry(partial(self.y_axis.move_to, y, speed=self.y_axis.max_speed),
+                              max_attempts=2, max_timeout=20.0)
+
+    async def punch(self, y: float) -> None:
+        """Punch at the given Y-offset (m, robot-local, before the implement's mounting offset)."""
+        y = round(y + self.offset.y, 5)
+        if not self.y_axis.min_position <= y <= self.y_axis.max_position:
+            raise ImplementException(f'y position {y} out of range')
+        if not await self.is_ready():
+            raise ImplementException('weeding screw is not ready (alarm or referencing failed)')
+        await rosys.run.retry(partial(self.y_axis.move_to, y), max_attempts=2, max_timeout=20.0)
+        await rosys.run.retry(partial(self.z_axis.move_to, -self.drill_depth), max_attempts=2, max_timeout=20.0)
+        await rosys.run.retry(self.z_axis.return_to_reference, max_attempts=2, max_timeout=20.0)
+
+    async def stop(self) -> None:
+        await self.z_axis.stop()
+        await self.y_axis.stop()
+
+    async def is_ready(self) -> bool:
+        if self.z_axis.alarm:
+            self.log.error('Z-Axis is in alarm, aborting')
+            return False
+        if self.y_axis.alarm:
+            self.log.error('Y-Axis is in alarm, aborting')
+            return False
+        if not self.z_axis.is_referenced and \
+                not await rosys.run.retry(self.z_axis.try_reference, max_attempts=2, max_timeout=60.0):
+            self.log.error('referencing Z-Axis failed, aborting')
+            return False
+        if not self.y_axis.is_referenced and \
+                not await rosys.run.retry(self.y_axis.try_reference, max_attempts=2, max_timeout=60.0):
+            self.log.error('referencing Y-Axis failed, aborting')
+            return False
+        return True
+
+    def can_reach(self, local_point: Point) -> bool:
+        axis_position = local_point.y + self.offset.y
+        return self.y_axis.min_position <= axis_position <= self.y_axis.max_position
+
+    def backup_to_dict(self) -> dict[str, Any]:
+        return {'drill_depth': self.drill_depth}
+
+    def restore_from_dict(self, data: dict[str, Any]) -> None:
+        self.drill_depth = data.get('drill_depth', self.drill_depth)
+
+    def _setup_y_axis(self, feldfreund: FeldfreundHardware | FeldfreundSimulation
+                      ) -> YAxisCanOpenHardware | AxisSimulation:
+        if rosys.is_simulation():
+            return AxisSimulation(min_position=self._config.y_axis.min_position,
+                                  max_position=self._config.y_axis.max_position,
+                                  axis_offset=self._config.y_axis.axis_offset)
+        assert isinstance(feldfreund, FeldfreundHardware)
+        return YAxisCanOpenHardware(self._config.y_axis, feldfreund.robot_brain,
+                                    can=feldfreund.can, expander=feldfreund.expander)
+
+    def _setup_z_axis(self, feldfreund: FeldfreundHardware | FeldfreundSimulation
+                      ) -> ZAxisCanOpenHardware | AxisSimulation:
+        if rosys.is_simulation():
+            return AxisSimulation(min_position=self._config.z_axis.min_position,
+                                  max_position=self._config.z_axis.max_position,
+                                  axis_offset=self._config.z_axis.axis_offset)
+        assert isinstance(feldfreund, FeldfreundHardware)
+        wheels = feldfreund.wheels
+        if not isinstance(wheels, TracksHardware):
+            raise ValueError(f'weeding screw drive interlock requires tracked wheels, got {type(wheels).__name__}')
+        return ZAxisCanOpenHardware(self._config.z_axis, feldfreund.robot_brain,
+                                    can=feldfreund.can, expander=feldfreund.expander, wheels=wheels)

--- a/devkit_driver/devkit_driver/weeding_screw/y_axis.py
+++ b/devkit_driver/devkit_driver/weeding_screw/y_axis.py
@@ -1,0 +1,214 @@
+# pylint: disable=duplicate-code
+import asyncio
+
+import rosys
+from feldfreund_devkit.hardware import SafetyMixin
+from rosys.automation import uninterruptible
+from rosys.helpers import remove_indentation
+
+from .axis import Axis
+from .configuration import YCanOpenConfiguration
+from .errors import CanOpenHardwareException
+
+
+class YAxisCanOpenHardware(Axis, rosys.hardware.ModuleHardware, SafetyMixin):
+    """Controls the horizontal axis using a CANopen motor."""
+
+    def __init__(self, config: YCanOpenConfiguration,
+                 robot_brain: rosys.hardware.RobotBrain, *,
+                 can: rosys.hardware.CanHardware,
+                 expander: rosys.hardware.ExpanderHardware | None) -> None:
+        self.config = config
+        self.expander = expander
+        self._ctrl_enable = False
+        self._initialized = False
+        self._operational = False
+        lizard_code = remove_indentation(f'''
+            {config.name}_motor = {expander.name + "." if config.motor_on_expander and expander else ""}CanOpenMotor({can.name}, {config.can_address})
+            {config.name}_end_l = {expander.name + "." if config.end_stops_on_expander and expander else ""}Input({config.end_left_pin})
+            {config.name}_end_l.inverted = {str(config.end_stops_inverted).lower()}
+            {config.name}_end_r = {expander.name + "." if config.end_stops_on_expander and expander else ""}Input({config.end_right_pin})
+            {config.name}_end_r.inverted = {str(config.end_stops_inverted).lower()}
+            {config.name} = {expander.name + "." if config.motor_on_expander and expander else ""}MotorAxis({config.name}_motor, {config.name + "_end_l" if config.reversed_direction else config.name + "_end_r"}, {config.name + "_end_r" if config.reversed_direction else config.name + "_end_l"})
+        ''')
+        core_message_fields = [
+            f'{config.name}_end_l.active',
+            f'{config.name}_end_r.active',
+            f'{config.name}_motor.actual_position',
+            f'{config.name}_motor.status_target_reached',
+            f'{config.name}_motor.status_fault',
+            f'{config.name}_motor.ctrl_enable',
+            f'{config.name}_motor.initialized',
+            f'{config.name}_motor.is_operational',
+        ]
+        super().__init__(max_speed=config.max_speed,
+                         reference_speed=config.reference_speed,
+                         min_position=config.min_position,
+                         max_position=config.max_position,
+                         axis_offset=config.axis_offset,
+                         steps_per_m=config.steps_per_m,
+                         reversed_direction=config.reversed_direction,
+                         robot_brain=robot_brain,
+                         lizard_code=lizard_code,
+                         core_message_fields=core_message_fields)
+
+    @property
+    def enable_code(self) -> str:
+        return f'{self.config.name}.enable();'
+
+    @property
+    def disable_code(self) -> str:
+        return f'{self.config.name}.disable();'
+
+    @property
+    def ctrl_enable(self) -> bool:
+        return self._ctrl_enable
+
+    @property
+    def initialized(self) -> bool:
+        return self._initialized
+
+    @property
+    def operational(self) -> bool:
+        return self._operational
+
+    async def stop(self) -> None:
+        self._stop_requested = True
+        if not self.robot_brain.is_ready:
+            self.log.warning('robot brain not ready')
+            return
+        await self.robot_brain.send(f'{self.config.name}_motor.set_ctrl_enable(false);')
+
+    @uninterruptible
+    async def move_to(self, position: float, speed: int | None = None) -> None:
+        self._stop_requested = False
+        if speed is None:
+            speed = self.max_speed
+        try:
+            await super().move_to(position, speed)
+        except RuntimeError as error:
+            self._raise_exception(f'could not move to {position} because of {error}')
+        steps = self.compute_steps(position)
+        assert self.robot_brain.is_ready, 'robot brain is not ready'
+        assert self.initialized, 'motor is not initialized'
+        assert self.operational, 'motor is not operational'
+        while self.steps != steps:
+            await rosys.sleep(0.2)
+            if self._stop_requested:
+                self.log.info('%s move stopped', self.config.name)
+                raise asyncio.CancelledError()
+            if self.alarm:
+                self._raise_exception('alarm state detected')
+            if not self.ctrl_enable:
+                self.log.warning('%s is not enabled, sending enable command', self.config.name)
+                await self.enable_motor()
+                continue
+            await self.robot_brain.send(f'{self.config.name}.position({steps},{speed}, 0);')
+        await self.robot_brain.send(f'{self.config.name}_motor.set_ctrl_halt(true);')
+
+    async def enable_motor(self) -> None:
+        await self.robot_brain.send(f'{self.config.name}_motor.set_ctrl_enable(true);')
+
+    async def disable_motor(self) -> None:
+        await self.robot_brain.send(f'{self.config.name}_motor.set_ctrl_enable(false);')
+
+    async def reset_fault(self) -> None:
+        await self.robot_brain.send(f'{self.config.name}_motor.reset_fault()')
+        await rosys.sleep(1.0)
+
+    async def recover(self) -> None:
+        await self.reset_fault()
+        await rosys.run.retry(self.try_reference, max_attempts=2, max_timeout=60.0)
+
+    @uninterruptible
+    async def try_reference(self) -> bool:
+        if not await super().try_reference():
+            return False
+        try:
+            assert self.robot_brain.is_ready, 'robot brain is not ready'
+            await self.enable_motor()
+            await rosys.sleep(1)
+            self.check_motor()
+            await self.robot_brain.send(f'{self.config.name}_motor.position_offset = 0;')
+            await rosys.sleep(1)
+            await self.robot_brain.send(f'{self.config.name}_motor.enter_pv_mode();')
+            await rosys.sleep(1)
+
+            # if in end l stop, move out
+            if self.end_l:
+                velocity = -self.reference_speed * (-1 if self.reversed_direction else 1)
+                await self.robot_brain.send(f'{self.config.name}.speed({velocity}, 0);')
+                while self.end_l:
+                    await rosys.sleep(0.2)
+                await self.robot_brain.send(f'{self.config.name}_motor.set_ctrl_halt(true);')
+            await rosys.sleep(0.5)
+
+            # move to end r stop if not already there
+            if not self.end_r:
+                velocity = -self.reference_speed * (-1 if self.reversed_direction else 1)
+                await self.robot_brain.send(f'{self.config.name}.speed({velocity}, 0);')
+                while not self.end_r:
+                    await rosys.sleep(0.2)
+            await rosys.sleep(0.5)
+
+            # move out of end r stop
+            velocity = self.reference_speed * (-1 if self.reversed_direction else 1)
+            await self.robot_brain.send(f'{self.config.name}.speed({velocity}, 0);')
+            while self.end_r:
+                await rosys.sleep(0.2)
+            await rosys.sleep(0.5)
+
+            # move slowly to end r stop
+            slow_velocity = -25 * (-1 if self.reversed_direction else 1)
+            await self.robot_brain.send(f'{self.config.name}.speed({slow_velocity}, 0);')
+            while not self.end_r:
+                await rosys.sleep(0.2)
+            await rosys.sleep(0.5)
+
+            # move slowly out of end r stop
+            slow_velocity = 25 * (-1 if self.reversed_direction else 1)
+            await self.robot_brain.send(f'{self.config.name}.speed({slow_velocity}, 0);')
+            while self.end_r:
+                await rosys.sleep(0.2)
+            await rosys.sleep(0.5)
+
+            await self.robot_brain.send(f'{self.config.name}_motor.enter_pv_mode(0);')
+            await self.robot_brain.send(f'{self.config.name}_motor.position_offset = {self.steps};')
+            await rosys.sleep(0.2)
+            self.is_referenced = True
+            await self.robot_brain.send(f'{self.config.name}_motor.enter_pp_mode(0);')
+            return True
+        except Exception as error:
+            self.log.error('could not reference %s because of %s', self.config.name, error)
+            return False
+        finally:
+            await self.stop()
+
+    def check_motor(self) -> None:
+        if self.alarm:
+            self._raise_exception('alarm state detected')
+        if not self.initialized:
+            self._raise_exception('is not initialized')
+        if not self.operational:
+            self._raise_exception('is not operational')
+        if not self.ctrl_enable:
+            self._raise_exception('is not enabled')
+
+    def _raise_exception(self, message: str) -> None:
+        self.is_referenced = False
+        self.log.error('%s %s', self.config.name, message)
+        raise CanOpenHardwareException(f'{self.config.name}: {message}')
+
+    def handle_core_output(self, time: float, words: list[str]) -> None:
+        self.end_l = words.pop(0) == 'true'
+        self.end_r = words.pop(0) == 'true'
+        if self.end_l or self.end_r:
+            self.is_referenced = False
+        self.steps = int(words.pop(0))
+        self.idle = words.pop(0) == 'true'
+        self.alarm = words.pop(0) == 'true'
+        if self.alarm:
+            self.is_referenced = False
+        self._ctrl_enable = words.pop(0) == 'true'
+        self._initialized = words.pop(0) == 'true'
+        self._operational = words.pop(0) == 'true'

--- a/devkit_driver/devkit_driver/weeding_screw/z_axis.py
+++ b/devkit_driver/devkit_driver/weeding_screw/z_axis.py
@@ -1,0 +1,267 @@
+# pylint: disable=duplicate-code
+import asyncio
+
+import rosys
+from feldfreund_devkit.hardware import SafetyMixin, TracksHardware
+from rosys.automation import uninterruptible
+from rosys.helpers import remove_indentation
+
+from .axis import Axis
+from .configuration import ZCanOpenConfiguration
+from .errors import CanOpenHardwareException
+
+
+class ZAxisCanOpenHardware(Axis, rosys.hardware.ModuleHardware, SafetyMixin):
+    """Controls the vertical axis using a CANopen motor, with a Lizard-side drive interlock."""
+
+    DRIVE_RELEASE_TOLERANCE = 0.01
+    """The screw counts as parked (drive released) within this distance (m) of its reference point."""
+
+    def __init__(self, config: ZCanOpenConfiguration,
+                 robot_brain: rosys.hardware.RobotBrain, *,
+                 can: rosys.hardware.CanHardware,
+                 expander: rosys.hardware.ExpanderHardware | None,
+                 wheels: TracksHardware) -> None:
+        self.config = config
+        self.expander = expander
+        self._ctrl_enable = False
+        self._initialized = False
+        self._operational = False
+
+        lizard_code = remove_indentation(f'''
+            {config.name}_motor = {expander.name + "." if config.motor_on_expander and expander else ""}CanOpenMotor({can.name}, {config.can_address})
+            {config.name}_end_t = {expander.name + "." if config.end_stops_on_expander and expander else ""}Input({config.end_top_pin})
+            {config.name}_end_t.inverted = {str(config.end_stops_inverted).lower()}
+            {config.name}_end_b = {expander.name + "." if config.end_stops_on_expander and expander else ""}Input({config.end_bottom_pin})
+            {config.name}_end_b.inverted = {str(config.end_stops_inverted).lower()}
+            {config.name} = {expander.name + "." if config.motor_on_expander and expander else ""}MotorAxis({config.name}_motor, {config.name + "_end_t" if config.reversed_direction else config.name + "_end_b"}, {config.name + "_end_b" if config.reversed_direction else config.name + "_end_t"})
+        ''')
+        flag = f'{config.name}_drive_release'
+        lizard_code += remove_indentation(f'''
+            bool {flag} = false
+            when {flag} then {wheels.name}.locked = false; end
+            when {flag} == false then {wheels.name}.locked = true; end
+        ''')
+        core_message_fields = [
+            f'{config.name}_end_t.active',
+            f'{config.name}_end_b.active',
+            f'{config.name}_motor.actual_position',
+            f'{config.name}_motor.status_target_reached',
+            f'{config.name}_motor.status_fault',
+            f'{config.name}_motor.ctrl_enable',
+            f'{config.name}_motor.initialized',
+            f'{config.name}_motor.is_operational',
+        ]
+        super().__init__(max_speed=config.max_speed,
+                         reference_speed=config.reference_speed,
+                         min_position=config.min_position,
+                         max_position=config.max_position,
+                         axis_offset=config.axis_offset,
+                         steps_per_m=config.steps_per_m,
+                         reversed_direction=config.reversed_direction,
+                         robot_brain=robot_brain,
+                         lizard_code=lizard_code,
+                         core_message_fields=core_message_fields)
+        self.REFERENCE_CHANGED.subscribe(self._refresh_drive_release, unsubscribe_on_delete=False)
+        self.REFERENCE_CHANGED.subscribe(self._notify_reference_lost, unsubscribe_on_delete=False)
+
+    @property
+    def enable_code(self) -> str:
+        return f'{self.config.name}.enable();'
+
+    @property
+    def disable_code(self) -> str:
+        return f'{self.config.name}.disable();'
+
+    @property
+    def ctrl_enable(self) -> bool:
+        return self._ctrl_enable
+
+    @property
+    def initialized(self) -> bool:
+        return self._initialized
+
+    @property
+    def operational(self) -> bool:
+        return self._operational
+
+    async def stop(self) -> None:
+        self._stop_requested = True
+        if not self.robot_brain.is_ready:
+            self.log.warning('robot brain not ready')
+            return
+        await self.robot_brain.send(f'{self.config.name}_motor.set_ctrl_enable(false);')
+
+    @uninterruptible
+    async def move_to(self, position: float, speed: int | None = None) -> None:
+        self._stop_requested = False
+        if speed is None:
+            speed = self.max_speed
+        try:
+            await super().move_to(position, speed)
+        except RuntimeError as error:
+            self._raise_exception(f'could not move to {position} because of {error}')
+        try:
+            steps = self.compute_steps(position)
+            assert self.robot_brain.is_ready, 'robot brain is not ready'
+            assert self.initialized, 'motor is not initialized'
+            assert self.operational, 'motor is not operational'
+            await self.robot_brain.send(f'{self.config.name}_drive_release = false;')  # lock for the move
+            while self.steps != steps:
+                await rosys.sleep(0.2)
+                if self._stop_requested:
+                    self.log.info('%s move stopped', self.config.name)
+                    raise asyncio.CancelledError()
+                if self.alarm:
+                    self._raise_exception('alarm state detected')
+                if not self.ctrl_enable:
+                    self.log.warning('%s is not enabled, sending enable command', self.config.name)
+                    await self.enable_motor()
+                    continue
+                await self.robot_brain.send(f'{self.config.name}.position({steps},{speed}, 0);')
+            await self.robot_brain.send(f'{self.config.name}_motor.set_ctrl_halt(true);')
+        finally:
+            # the loop leaves the streamed steps at the target, so this reads where the screw is;
+            # an error or cancel judges wherever it came to a halt
+            await self._refresh_drive_release()
+
+    def _is_parked(self, position: float) -> bool:
+        """Whether the screw is retracted close enough to its reference for the robot to drive."""
+        return abs(position - self.compute_position(0)) < self.DRIVE_RELEASE_TOLERANCE
+
+    async def _refresh_drive_release(self) -> None:
+        """Lock or release the wheels according to where the screw actually is.
+
+        The brain's only input on whether the screw is parked, subscribed to the reference edge and
+        called after every move. The value is derived right before it goes out, so concurrent callers
+        reach the brain in the order they read the state. Callers must make sure the streamed steps
+        are current: right after writing ``position_offset`` they are not.
+
+        Skipped while the brain is unreachable, which is safe in both directions: the brain declares
+        the flag as false on every restart and cannot drive while it is down.
+        """
+        if not self.robot_brain.is_ready:
+            self.log.warning('robot brain not ready')
+            return
+        released = self.is_referenced and self._is_parked(self.position)
+        await self.robot_brain.send(f'{self.config.name}_drive_release = {str(released).lower()};')
+
+    def _notify_reference_lost(self, is_referenced: bool) -> None:
+        if is_referenced:
+            return
+        self.log.warning('%s lost its reference; driving stays locked until it is referenced again', self.config.name)
+
+    async def enable_motor(self) -> None:
+        await self.robot_brain.send(f'{self.config.name}_motor.set_ctrl_enable(true);')
+
+    async def disable_motor(self) -> None:
+        await self.robot_brain.send(f'{self.config.name}_motor.set_ctrl_enable(false);')
+
+    async def reset_fault(self) -> None:
+        await self.robot_brain.send(f'{self.config.name}_motor.reset_fault()')
+        await rosys.sleep(1.0)
+
+    async def recover(self) -> None:
+        await self.reset_fault()
+        await rosys.run.retry(self.try_reference, max_attempts=2, max_timeout=60.0)
+
+    @uninterruptible
+    async def try_reference(self) -> bool:
+        if not await super().try_reference():
+            return False
+        try:
+            assert self.robot_brain.is_ready, 'robot brain is not ready'
+            await self.robot_brain.send(f'{self.config.name}_drive_release = false;')  # lock while homing
+            await self.enable_motor()
+            await rosys.sleep(1)
+            self.check_motor()
+            await self.robot_brain.send(f'{self.config.name}_motor.position_offset = 0;')
+            await rosys.sleep(1)
+            await self.robot_brain.send(f'{self.config.name}_motor.enter_pv_mode();')
+            await rosys.sleep(1)
+
+            # if in end b stop, move out
+            if self.end_b:
+                velocity = self.reference_speed * (-1 if self.reversed_direction else 1)
+                await self.robot_brain.send(f'{self.config.name}.speed({velocity}, 0);')
+                while self.end_b:
+                    await rosys.sleep(0.2)
+                await self.robot_brain.send(f'{self.config.name}_motor.set_ctrl_halt(true);')
+            await rosys.sleep(0.5)
+
+            # move to end t stop if not already there
+            if not self.end_t:
+                velocity = self.reference_speed * (-1 if self.reversed_direction else 1)
+                await self.robot_brain.send(f'{self.config.name}.speed({velocity}, 0);')
+                while not self.end_t:
+                    await rosys.sleep(0.2)
+            await rosys.sleep(0.5)
+
+            # move out of end t stop
+            velocity = -self.reference_speed * (-1 if self.reversed_direction else 1)
+            await self.robot_brain.send(f'{self.config.name}.speed({velocity}, 0);')
+            while self.end_t:
+                await rosys.sleep(0.2)
+            await rosys.sleep(0.5)
+
+            # move slowly to end t stop
+            slow_velocity = 25 * (-1 if self.reversed_direction else 1)
+            await self.robot_brain.send(f'{self.config.name}.speed({slow_velocity}, 0);')
+            while not self.end_t:
+                await rosys.sleep(0.2)
+            await rosys.sleep(0.5)
+
+            # move slowly out of end t stop
+            slow_velocity = -25 * (-1 if self.reversed_direction else 1)
+            await self.robot_brain.send(f'{self.config.name}.speed({slow_velocity}, 0);')
+            while self.end_t:
+                await rosys.sleep(0.2)
+            await rosys.sleep(0.5)
+
+            await self.robot_brain.send(f'{self.config.name}_motor.position_offset = {self.steps};')
+            # frames already in flight still carry the raw count, which at this axis' resolution
+            # sits far outside the release band, so wait for the re-based one
+            deadline = rosys.time() + 2.0
+            while not self._is_parked(self.position):
+                if rosys.time() >= deadline:
+                    raise TimeoutError(f'position {self.position} did not settle at the reference')
+                await rosys.sleep(0.1)
+            self.is_referenced = True
+            return True
+        except Exception as error:
+            self.log.error('could not reference %s because of %s', self.config.name, error)
+            return False
+        finally:
+            await self.stop()
+            # the steps are re-based on the reference point now, so this reads whether the screw
+            # ended up parked; a failed or cancelled reference has no reference and stays locked
+            await self._refresh_drive_release()
+
+    def check_motor(self) -> None:
+        if self.alarm:
+            self._raise_exception('alarm state detected')
+        if not self.initialized:
+            self._raise_exception('is not initialized')
+        if not self.operational:
+            self._raise_exception('is not operational')
+        if not self.ctrl_enable:
+            self._raise_exception('is not enabled')
+
+    def _raise_exception(self, message: str) -> None:
+        self.is_referenced = False
+        self.log.error('%s %s', self.config.name, message)
+        raise CanOpenHardwareException(f'{self.config.name}: {message}')
+
+    def handle_core_output(self, time: float, words: list[str]) -> None:
+        self.end_t = words.pop(0) == 'true'
+        self.end_b = words.pop(0) == 'true'
+        if self.end_t or self.end_b:
+            self.is_referenced = False
+        self.steps = int(words.pop(0))
+        self.idle = words.pop(0) == 'true'
+        self.alarm = words.pop(0) == 'true'
+        if self.alarm:
+            self.is_referenced = False
+        self._ctrl_enable = words.pop(0) == 'true'
+        self._initialized = words.pop(0) == 'true'
+        self._operational = words.pop(0) == 'true'

--- a/devkit_ui/devkit_ui/dashboard.py
+++ b/devkit_ui/devkit_ui/dashboard.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from nicegui import ui
-from std_msgs.msg import Empty
+from std_msgs.msg import Empty, Float64
 
 if TYPE_CHECKING:
     from .node import NiceGuiNode
@@ -35,12 +35,14 @@ class Dashboard:
             self._data_card()
             self._safety_card()
         self._esp_card()
+        self._weeding_screw_card()
         self._gps_card()
         # NiceGUI has no auto-refresh, so poll the data-driven parts on a timer. The
         # joystick lives in the (non-refreshed) control card so dragging is never interrupted.
         ui.timer(UI_REFRESH_INTERVAL, self._estop_button.refresh)
         ui.timer(UI_REFRESH_INTERVAL, self._data_card.refresh)
         ui.timer(UI_REFRESH_INTERVAL, self._safety_card.refresh)
+        ui.timer(UI_REFRESH_INTERVAL, self._weeding_screw_status.refresh)
 
     def _control_card(self) -> None:
         node = self._node
@@ -109,6 +111,42 @@ class Dashboard:
                           on_click=lambda: node.esp_restart_publisher.publish(Empty())).classes('w-24')
                 ui.button('Configure', color='purple',
                           on_click=lambda: node.esp_configure_publisher.publish(Empty())).classes('w-24')
+
+    def _weeding_screw_card(self) -> None:
+        node = self._node
+        with ui.card().classes('w-[48rem] items-center mt-3'):
+            ui.label('Weeding Screw').classes('text-2xl')
+            with ui.row().classes('gap-4'):
+                ui.button('Home', color='blue',
+                          on_click=lambda: node.weeding_screw_home_publisher.publish(Empty())).classes('w-28')
+                ui.button('Clear View', color='blue',
+                          on_click=lambda: node.weeding_screw_clear_view_publisher.publish(Empty())).classes('w-28')
+                ui.button('Stop', color='red',
+                          on_click=lambda: node.weeding_screw_stop_publisher.publish(Empty())).classes('w-28')
+            with ui.row().classes('items-center gap-2 mt-3'):
+                y_input = ui.number('Y-offset', value=0.0, step=0.005, format='%.3f') \
+                    .props('dense outlined suffix=m').classes('w-32')
+                ui.button('Punch', color='purple',
+                          on_click=lambda: node.weeding_screw_punch_publisher.publish(Float64(data=y_input.value))) \
+                    .classes('w-24')
+            with ui.row().classes('items-center gap-2 mt-2'):
+                depth_input = ui.number('Drill depth', value=0.14, step=0.01, format='%.2f') \
+                    .props('dense outlined suffix=m').classes('w-32')
+                ui.button('Set Depth', color='teal',
+                          on_click=lambda: node.weeding_screw_set_drill_depth_publisher.publish(
+                              Float64(data=depth_input.value))) \
+                    .classes('w-28')
+            self._weeding_screw_status()
+
+    @ui.refreshable_method
+    def _weeding_screw_status(self) -> None:
+        node = self._node
+        with ui.row().classes('gap-6 mt-2'):
+            self._status_label('Referenced', node.weeding_screw_is_referenced)
+            self._status_label('Alarm', node.weeding_screw_alarm)
+            ui.label(f'Y: {node.weeding_screw_y_position:.3f} m').classes('text-sm')
+            ui.label(f'Z: {node.weeding_screw_z_position:.3f} m').classes('text-sm')
+            ui.label(f'Depth: {node.weeding_screw_drill_depth:.3f} m').classes('text-sm')
 
     def _gps_card(self) -> None:
         with ui.card().classes('w-[48rem] items-center mt-3'):

--- a/devkit_ui/devkit_ui/node.py
+++ b/devkit_ui/devkit_ui/node.py
@@ -6,7 +6,7 @@ from gps_msgs.msg import GPSFix
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, Duration, LivelinessPolicy, QoSProfile, ReliabilityPolicy
 from sensor_msgs.msg import BatteryState
-from std_msgs.msg import Bool, Empty
+from std_msgs.msg import Bool, Empty, Float64
 
 from .dashboard import Dashboard
 
@@ -35,6 +35,11 @@ class NiceGuiNode(Node):
         self.esp_restart_publisher = self.create_publisher(Empty, 'esp/restart', 1)
         self.esp_configure_publisher = self.create_publisher(Empty, 'esp/configure', 1)
         self.estop_publisher = self.create_publisher(Bool, 'estop/soft', SAFETY_QOS)
+        self.weeding_screw_home_publisher = self.create_publisher(Empty, 'weeding_screw/home', 1)
+        self.weeding_screw_clear_view_publisher = self.create_publisher(Empty, 'weeding_screw/clear_view', 1)
+        self.weeding_screw_stop_publisher = self.create_publisher(Empty, 'weeding_screw/stop', 1)
+        self.weeding_screw_punch_publisher = self.create_publisher(Float64, 'weeding_screw/punch', 1)
+        self.weeding_screw_set_drill_depth_publisher = self.create_publisher(Float64, 'weeding_screw/set_drill_depth', 1)
 
         self.create_subscription(GPSFix, 'gpsfix', self.store_gps, 1)
         self.create_subscription(BatteryState, 'battery_state', self.store_battery, 1)
@@ -43,6 +48,11 @@ class NiceGuiNode(Node):
         self.create_subscription(Bool, 'bumper/back', self.update_bumper_back, SAFETY_QOS)
         self.create_subscription(Bool, 'estop/front', self.update_estop_front, SAFETY_QOS)
         self.create_subscription(Bool, 'estop/back', self.update_estop_back, SAFETY_QOS)
+        self.create_subscription(Float64, 'weeding_screw/y_position', self.update_weeding_screw_y_position, 1)
+        self.create_subscription(Float64, 'weeding_screw/z_position', self.update_weeding_screw_z_position, 1)
+        self.create_subscription(Bool, 'weeding_screw/is_referenced', self.update_weeding_screw_is_referenced, SAFETY_QOS)
+        self.create_subscription(Bool, 'weeding_screw/alarm', self.update_weeding_screw_alarm, SAFETY_QOS)
+        self.create_subscription(Float64, 'weeding_screw/drill_depth', self.update_weeding_screw_drill_depth, 1)
 
         # State polled by the dashboard cards (written from the ROS subscription callbacks).
         self.bumper_front_top_active = False
@@ -55,6 +65,11 @@ class NiceGuiNode(Node):
         self.angular_velocity = 0.0
         self.latest_gps: GPSFix | None = None
         self.latest_battery: BatteryState | None = None
+        self.weeding_screw_y_position = 0.0
+        self.weeding_screw_z_position = 0.0
+        self.weeding_screw_is_referenced = False
+        self.weeding_screw_alarm = False
+        self.weeding_screw_drill_depth = 0.14  # updated once the driver reports the actual value
 
         self._dashboard = Dashboard(self)
 
@@ -98,3 +113,18 @@ class NiceGuiNode(Node):
 
     def update_estop_back(self, msg: Bool) -> None:
         self.estop_back_active = msg.data
+
+    def update_weeding_screw_y_position(self, msg: Float64) -> None:
+        self.weeding_screw_y_position = msg.data
+
+    def update_weeding_screw_z_position(self, msg: Float64) -> None:
+        self.weeding_screw_z_position = msg.data
+
+    def update_weeding_screw_is_referenced(self, msg: Bool) -> None:
+        self.weeding_screw_is_referenced = msg.data
+
+    def update_weeding_screw_alarm(self, msg: Bool) -> None:
+        self.weeding_screw_alarm = msg.data
+
+    def update_weeding_screw_drill_depth(self, msg: Float64) -> None:
+        self.weeding_screw_drill_depth = msg.data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Shared pytest fixtures for the driver test suite.
+
+`make test` runs with PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 (see the Makefile: the ROS
+launch_testing pytest plugins are incompatible with modern pytest, so plugin autoloading is
+disabled and only pytest-asyncio is loaded explicitly). That also disables rosys's own pytest11
+plugin registration, so its testing fixtures (rosys_integration, forward, ...) need to be
+imported here explicitly instead of relying on autodiscovery.
+"""
+from rosys.testing.fixtures import enforce_spawn_process, rosys_integration
+
+__all__ = ['enforce_spawn_process', 'rosys_integration']

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -23,5 +23,6 @@ def test_all_handler_modules_import() -> None:
         modules.OdomHandler,
         modules.RobotBrainHandler,
         modules.TwistHandler,
+        modules.WeedingScrewHandler,
     )
     assert all(handler is not None for handler in handlers)

--- a/tests/test_weeding_screw.py
+++ b/tests/test_weeding_screw.py
@@ -1,0 +1,35 @@
+"""Regression test for the weeding screw axis.
+
+Guards against a real bug found during the first f18 hardware test: stop() only disabled the
+motor for one poll cycle, and the still-running move_to() loop noticed the motor was disabled and
+simply re-enabled it itself - "stop" paused the axis for a moment instead of aborting the move.
+The first fix attempt (cancelling the caller's asyncio task) didn't help either: every move_to()
+call goes through rosys.run.retry(..., max_timeout=...), which runs the move in its own detached
+task internally, so cancelling the caller never reaches it. Only a flag the axis checks itself
+(set by stop(), read inside move_to()'s own poll loop) actually works, regardless of which task
+called it.
+"""
+import rosys
+from devkit_driver.weeding_screw import AxisSimulation
+from rosys.hardware import RobotSimulation
+from rosys.testing import forward
+
+
+async def test_stop_aborts_an_in_progress_move(rosys_integration: None) -> None:
+    axis = AxisSimulation(min_position=-0.2, max_position=0.0)
+    robot = RobotSimulation([axis])  # keep alive: on_repeat only holds a weak-ish handle
+    assert await axis.try_reference()
+
+    move_task = rosys.background_tasks.create(axis.move_to(-0.19, speed=50))
+    await forward(seconds=0.5)
+    position_before_stop = axis.position
+    assert position_before_stop < -0.02, 'the move should be well underway by now'
+
+    await axis.stop()
+    await forward(seconds=1.0)
+
+    assert move_task.done()
+    assert move_task.cancelled()
+    assert axis.position == position_before_stop, 'the axis must not keep moving after stop()'
+    assert axis.position > -0.15, 'the axis should have stopped well short of its target'
+    del robot


### PR DESCRIPTION
Manual ROS control for the weeding screw (f18's Y-/Z-axis punch tool), ported from `feldfreund` as a template (no new dependency on `feldfreund`/`feldfreund_devkit` — both keep running in production untouched). Concept/architecture writeup: an earlier internal proposal covered the isolated-port decision and scope; this PR implements it.

**Scope, deliberately manual-only** (matches this repo's current phase — no navigation/camera targeting yet anywhere in `devkit_ros`):
- ✅ home, clear-view, stop, punch-at-Y-offset, live drill-depth setting, status
- ❌ camera-based weed targeting, `FieldNavigation`-driven autonomous weeding — no perception pipeline on the ROS side yet

**Not included:** any robot's real axis config (CAN addresses, pins, etc.). `devkit_launch/config/feldfreund.py` stays the generic example it already was — same treatment as the other robot-specific values (bumper pins, flashlight, GNSS offset, …) that have stayed out of this repo so far. Any robot wanting this implement wires its own `WeedingScrewConfiguration` into its own config file.

### What's in here
1. **`devkit_driver/weeding_screw/`** — config dataclasses (CANopen variant only), `Axis`/`AxisSimulation` base, `YAxisCanOpenHardware`/`ZAxisCanOpenHardware` (including the safety-critical drive interlock: wheels stay locked in Lizard firmware until the Z-axis is referenced and parked within tolerance), and a `WeedingScrew` implement class.
2. **ROS wiring** — `WeedingScrewHandler` (topics for home/clear_view/stop/punch/set_drill_depth + state), wired into `devkit_driver_node.py` generically (`isinstance(config.implement, WeedingScrewConfiguration)`).
3. **Web UI** — a "Weeding Screw" card in the dashboard, same pattern as the existing "ESP Control" card.
4. **Tests** — a regression test for a real stop-bug found during hardware testing (below), plus the new handler added to the existing import smoke test.

### A real bug found (and fixed) during hardware testing

First attempt: `stop()` only disabled the motor for one poll cycle — the still-running `move_to()` loop noticed and re-enabled it itself, so "stop" briefly paused the axis instead of aborting the move. Cancelling the caller's asyncio task didn't fix it either: every `move_to()` call goes through `rosys.run.retry(..., max_timeout=...)`, which runs the move in its **own detached asyncio task** internally — the caller's cancellation never reaches it.

Fix: a cooperative `_stop_requested` flag the axis checks in its own poll loop, set by `stop()` — the only mechanism that reliably aborts an in-progress move regardless of which task called it. `tests/test_weeding_screw.py` guards against a regression (verified it fails without the fix before adding it).

### Testing
- ruff/pylint (10.00/10)/mypy clean
- Full manual test matrix run on **real f18 hardware** (robot jacked up, reduced punch depth for clearance): drive interlock locked before homing / released once parked / relocked mid-punch, home, punch at multiple Y-offsets (confirmed real targeting, not a fixed spot), clear-view in both directions including the y=0 boundary case, and stop genuinely aborting an in-progress punch after the fix above
- Also verified in `devkit-simulation` (Docker) on this exact branch, with a temporary local-only test config assigning a `WeedingScrewConfiguration` (not committed) — same home/punch/stop sequence, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Note on CI:** `code-checks (make pylint)` fails, but this is **pre-existing and unrelated** — the same `duplicate-code` (R0801) note between `devkit_driver_node.py` and `ui_node.py` already documented in #21, present on `main` itself. Not touched here to keep this PR scoped. `code-checks (make mypy)` shows as failed too, but that's just the matrix's fail-fast cancelling it after pylint fails — it reports "Success: no issues found" in its own log before being cancelled.
