### PR TITLE
Subscribe to estop/soft with the safety QoS so a respawned driver keeps a latched soft e-stop

### DIFF
--- a/devkit_driver/devkit_driver/modules/estop_handler.py
+++ b/devkit_driver/devkit_driver/modules/estop_handler.py
@@ -17,7 +17,7 @@ class EStopHandler(Handler):
         super().__init__(node)
         self._estop = estop
 
-        self.subscription = node.create_subscription(Bool, 'estop/soft', self.soft_estop_callback, 10)
+        self.subscription = node.create_subscription(Bool, 'estop/soft', self.soft_estop_callback, SAFETY_QOS)
         self.estop_front_publisher = node.create_publisher(Bool, 'estop/front', SAFETY_QOS)
         self.estop_back_publisher = node.create_publisher(Bool, 'estop/back', SAFETY_QOS)
 

--- a/tests/test_estop_handler.py
+++ b/tests/test_estop_handler.py
@@ -1,0 +1,30 @@
+"""Check that the driver picks up a soft e-stop that was latched before it started."""
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+import rclpy
+from devkit_driver.modules import EStopHandler
+from devkit_driver.qos import SAFETY_QOS
+from rclpy.node import Node
+from std_msgs.msg import Bool
+
+
+def test_late_joining_driver_receives_latched_soft_estop(monkeypatch: pytest.MonkeyPatch) -> None:
+    callback = MagicMock()
+    monkeypatch.setattr(EStopHandler, 'soft_estop_callback', callback)
+    rclpy.init()
+    try:
+        node = Node('test_estop_handler')
+        publisher = node.create_publisher(Bool, 'estop/soft', SAFETY_QOS)
+        publisher.publish(Bool(data=True))
+
+        EStopHandler(node, MagicMock())
+        deadline = time.monotonic() + 5.0
+        while not callback.called and time.monotonic() < deadline:
+            rclpy.spin_once(node, timeout_sec=0.1)
+        assert callback.called
+        assert callback.call_args.args[0].data is True
+    finally:
+        rclpy.shutdown()


### PR DESCRIPTION
### Motivation

Follow-up to the review of #17 (https://github.com/zauberzeug/feldfreund_devkit_ros/pull/17#issuecomment-5139969783). The UI publishes `estop/soft` with `SAFETY_QOS` (TRANSIENT_LOCAL), but the driver subscribed with a bare depth of 10, which is VOLATILE. A driver-only respawn therefore never saw a soft e-stop that was latched before it started, and the robot came up released while the UI still showed it stopped.

### Implementation

- Subscribe to `estop/soft` in `EStopHandler` with `SAFETY_QOS` so the late-joining driver receives the latched sample.
- Add `tests/test_estop_handler.py`: publishes before the handler exists and spins until the callback fires; fails against the previous depth-10 subscription.

<details><summary>Details</summary>

Verified in the local `devkit_ros` image (ros:jazzy): full suite passes with the fix, the new test fails with the old subscription. `ruff` passes. The duplicated `SAFETY_QOS` definition in `devkit_ui/node.py` is left as is; the UI package does not depend on `devkit_driver`.

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added.
- [x] Documentation has been added (or is not necessary).

</details>

[※](https://zauberzeug.github.io/colophon/#m=claude-fable-5-1&t=Defect%20reported%20by%20the%20reviewer%20of%20%2317%3B%20fix%2C%20regression%20test%20and%20this%20text%20from%20the%20model.&a=claude-code "claude-fable-5-1: Defect reported by the reviewer of #17; fix, regression test and this text from the model.")
