### PR TITLE
Add a mobile-app button to reference the weeding screw

### DIFF
--- a/devkit_driver/devkit_driver/devkit_driver_node.py
+++ b/devkit_driver/devkit_driver/devkit_driver_node.py
@@ -15,8 +15,10 @@ from nicegui import app, ui, ui_run
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from rosgraph_msgs.msg import Clock
+from rosys.automation.app_controls_ import AppControls
 
 from devkit_driver.modules import (
+    AppControlsHandler,
     BMSHandler,
     BumperHandler,
     EStopHandler,
@@ -24,6 +26,7 @@ from devkit_driver.modules import (
     RobotBrainHandler,
     TwistHandler,
     WeedingScrewHandler,
+    create_app_controls,
 )
 from devkit_driver.weeding_screw import WeedingScrew, WeedingScrewConfiguration
 
@@ -31,7 +34,7 @@ from devkit_driver.weeding_screw import WeedingScrew, WeedingScrewConfiguration
 class DevkitDriver(Node):
     """Devkit node handler."""
 
-    def __init__(self, system: System):
+    def __init__(self, system: System, app_controls: AppControls | None):
         super().__init__('devkit_driver_node')
         self.system = system
 
@@ -58,6 +61,8 @@ class DevkitDriver(Node):
         self._estop_handler = EStopHandler(self, self.system.feldfreund.estop)
         if isinstance(self.system.feldfreund.implement, WeedingScrew):
             self._weeding_screw_handler = WeedingScrewHandler(self, self.system.feldfreund.implement)
+            if app_controls is not None:
+                self._app_controls_handler = AppControlsHandler(self, app_controls)
 
     def _publish_clock(self) -> None:
         """Publish RoSys simulation time to ROS2 /clock topic."""
@@ -74,8 +79,10 @@ class DevkitDriver(Node):
 
 
 class _State:
-    """Module-level container for the spinning ROS thread (avoids a global statement)."""
+    """Module-level container for objects shared between `on_startup()` and the ROS thread
+    (avoids global statements)."""
     ros_thread: threading.Thread | None = None
+    app_controls: AppControls | None = None
 
 
 _state = _State()
@@ -97,8 +104,12 @@ def on_startup() -> None:
     system = System(config, secrets=secrets)
     if isinstance(config.implement, WeedingScrewConfiguration):
         system.feldfreund.add_implement(WeedingScrew(config.implement, system.feldfreund))
+    # Built here, synchronously, rather than later in DevkitDriver (ROS thread) - see
+    # create_app_controls' docstring for why that matters.
+    if isinstance(system.feldfreund, FeldfreundHardware) and isinstance(system.feldfreund.implement, WeedingScrew):
+        _state.app_controls = create_app_controls(system.feldfreund.robot_brain, system.feldfreund.bluetooth)
     api.Online()
-    _state.ros_thread = threading.Thread(target=ros_main, args=(system,), name='ros_spin')
+    _state.ros_thread = threading.Thread(target=ros_main, args=(system, _state.app_controls), name='ros_spin')
     _state.ros_thread.start()
 
 
@@ -113,9 +124,9 @@ def on_shutdown() -> None:
                 'ROS spin thread did not terminate within 5s of shutdown; abandoning it')
 
 
-def ros_main(system: System) -> None:
+def ros_main(system: System, app_controls: AppControls | None) -> None:
     rclpy.init()
-    devkit_driver = DevkitDriver(system)
+    devkit_driver = DevkitDriver(system, app_controls)
     try:
         rclpy.spin(devkit_driver)
     except ExternalShutdownException:

--- a/devkit_driver/devkit_driver/modules/__init__.py
+++ b/devkit_driver/devkit_driver/modules/__init__.py
@@ -1,3 +1,4 @@
+from .app_controls_handler import AppControlsHandler, create_app_controls
 from .bms_handler import BMSHandler
 from .bumper_handler import BumperHandler
 from .estop_handler import EStopHandler
@@ -7,6 +8,7 @@ from .twist_handler import TwistHandler
 from .weeding_screw_handler import WeedingScrewHandler
 
 __all__ = [
+    'AppControlsHandler',
     'BMSHandler',
     'BumperHandler',
     'EStopHandler',
@@ -14,4 +16,5 @@ __all__ = [
     'RobotBrainHandler',
     'TwistHandler',
     'WeedingScrewHandler',
+    'create_app_controls',
 ]

--- a/devkit_driver/devkit_driver/modules/app_controls_handler.py
+++ b/devkit_driver/devkit_driver/modules/app_controls_handler.py
@@ -1,0 +1,41 @@
+from rclpy.node import Node
+from rosys.automation import AppButton, Automator
+from rosys.automation.app_controls_ import AppControls
+from rosys.hardware import BluetoothHardware, RobotBrain
+from std_msgs.msg import Empty
+
+from .base import Handler
+
+
+def create_app_controls(robot_brain: RobotBrain, bluetooth: BluetoothHardware) -> AppControls:
+    """Build the RoSys-level `AppControls` object.
+
+    Must be called synchronously right after `System(...)`, before the ROS node thread starts -
+    not from `DevkitDriver.__init__`. `AppControls` subscribes to `robot_brain.ESP_CONNECTED` in
+    its constructor, a one-shot event that fires once `RobotBrain`'s own `rosys.on_startup(self.
+    enable_esp)` completes; the ROS thread needs to spin up rclpy/DDS first, so by the time it
+    would construct this, that event has already fired and passed. Missing it leaves the app's
+    button toolbar permanently empty (never synced) even though driving and telemetry, which don't
+    depend on it, work fine - constructing it here instead, synchronously alongside `System(...)`,
+    guarantees the subscription is in place before RoSys's startup tasks get to run at all.
+    """
+    return AppControls(robot_brain, Automator(None, notify=False), bluetooth=bluetooth)
+
+
+class AppControlsHandler(Handler):
+    """Expose the weeding screw's home routine as a mobile-app button.
+
+    Ports the "reference implement" icon from the old feldfreund app - lost when the app/BLE
+    integration wasn't carried over during the ROS migration - but as a ROS publisher rather than
+    a direct call into the implement: pressing the button publishes to the same `weeding_screw/home`
+    topic the web dashboard's Home button already uses (see `WeedingScrewHandler`), so both sources
+    drive the implement through the one existing command path instead of a second, app-specific one.
+    """
+
+    def __init__(self, node: Node, app_controls: AppControls):
+        super().__init__(node)
+        self._home_publisher = node.create_publisher(Empty, 'weeding_screw/home', 10)
+        app_controls.extra_buttons['reference_implement'] = AppButton('build', released=self._handle_reference)
+
+    def _handle_reference(self) -> None:
+        self._home_publisher.publish(Empty())

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -17,6 +17,7 @@ def test_qos_profile_is_configured() -> None:
 
 def test_all_handler_modules_import() -> None:
     handlers = (
+        modules.AppControlsHandler,
         modules.BMSHandler,
         modules.BumperHandler,
         modules.EStopHandler,
@@ -26,3 +27,4 @@ def test_all_handler_modules_import() -> None:
         modules.WeedingScrewHandler,
     )
     assert all(handler is not None for handler in handlers)
+    assert modules.create_app_controls is not None


### PR DESCRIPTION
### Motivation

The pre-ROS `feldfreund` app exposed an app-only "reference implement" icon (`app_controls.py`) that homed the active implement over the Bluetooth app-controls channel, so the robot could be homed using only the mobile app. That icon disappeared during the migration to `feldfreund_devkit_ros`: the BLE/`AppControls` integration was never carried over at all (only the web dashboard kept a Home button - see #22).

### Implementation

Adds `AppControlsHandler`, following the existing `Handler` pattern (`WeedingScrewHandler`, `RobotBrainHandler`): pressing the app button publishes to the same `weeding_screw/home` topic the dashboard's Home button already uses, rather than calling into the implement directly - both sources drive it through the one existing command path instead of a second, app-specific one.

One deliberate deviation from the "one handler class per file" convention: `create_app_controls()` is a plain factory function, not a `Handler`. It has to build the RoSys-level `AppControls` object (the BLE/Lizard protocol layer) **synchronously inside `on_startup()`**, before the ROS node thread starts. `AppControls` subscribes to `robot_brain.ESP_CONNECTED` in its constructor - a one-shot event that `RobotBrain`'s own `rosys.on_startup(enable_esp)` fires well before the ROS thread gets around to spinning up rclpy/DDS. Building it later (inside `DevkitDriver`, as first tried) misses that event: driving and telemetry keep working fine through their own unrelated paths, but the app's button toolbar never receives any state at all - confirmed on real hardware before the fix. `DevkitDriver` only wires the ROS-specific publisher and button onto the already-connected object.

Based on #22 (needs `WeedingScrew`/`WeedingScrewHandler` to exist) - independent of #21 otherwise (no shared files).

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary). - hardware-tested end to end on f18 (rb47): button visible in the app, tap triggers `weeding_screw/home`, `is_referenced` flips to `true`.
- [x] Pytests have been added (or are not necessary). - extended the existing handler-import smoke test.
- [ ] Documentation has been added (or is not necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)